### PR TITLE
[job](sql) Kill sleep code in backup/restore

### DIFF
--- a/ccr/base/spec.go
+++ b/ccr/base/spec.go
@@ -227,8 +227,5 @@ func (s *Spec) CreateSnapshotAndWaitForDone() (string, error) {
 		return "", err
 	}
 
-	// TODO(impl): Add wait for done
-	time.Sleep(30 * time.Second)
-
 	return snapshotName, nil
 }

--- a/shell/start_syncer.sh
+++ b/shell/start_syncer.sh
@@ -38,6 +38,7 @@ PID_DIR="$(
 )"
 export PID_DIR
 
+LOG_DIR="${SYNCER_HOME}/log"
 
 pidfile="${PID_DIR}/syncer.pid"
 if [[ -f "${pidfile}" ]]; then
@@ -50,10 +51,10 @@ if [[ -f "${pidfile}" ]]; then
 fi
 
 chmod 755 "${SYNCER_HOME}/bin/ccr_syncer"
-echo "start time: $(date)" >>"${LOG_DIR}/ccr_syncer.out"
+echo "start time: $(date)" >>"${LOG_DIR}/ccr_syncer.log"
 
 if [[ "${RUN_DAEMON}" -eq 1 ]]; then
-    nohup "${SYNCER_HOME}/bin/ccr_syncer" "$@" >>"${LOG_DIR}/ccr_syncer.out" 2>&1 </dev/null &
+    nohup "${SYNCER_HOME}/bin/ccr_syncer" "$@" >>"${LOG_DIR}/ccr_syncer.log" 2>&1 </dev/null &
     echo $! > bin/syncer.pid
 else
     "${SYNCER_HOME}/bin/ccr_syncer" "$@" 2>&1 </dev/null


### PR DESCRIPTION
add func: 
```go
func makeSingleColScanArgs[T interface{}](prefix int, col *T, suffix int) []interface{}
func checkBackupFinished(sepc *base.Spec, snapshotName string) (bool, error)
func checkRestoreFinished(sepc *base.Spec, snapshotName string) (bool, error)
```