### PR TITLE
remove default_cluster prefix of db name for Doris v2.1

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -1019,6 +1019,7 @@ func (j *Job) handleLightningSchemaChange(binlog *festruct.TBinlog) error {
 	rawSql := lightningSchemaChange.RawSql
 	//   "rawSql": "ALTER TABLE `default_cluster:ccr`.`test_ddl` ADD COLUMN `nid1` int(11) NULL COMMENT \"\""
 	// replace `default_cluster:${Src.Database}`.`test_ddl` to `test_ddl`
+	// ATTN: default_cluster prefix will be removed in Doris v2.1
 	sql := strings.Replace(rawSql, fmt.Sprintf("`default_cluster:%s`.", j.Src.Database), "", 1)
 	log.Infof("lightningSchemaChangeSql, rawSql: %s, sql: %s", rawSql, sql)
 	return j.IDest.DbExec(sql)

--- a/pkg/ccr/job_test.go
+++ b/pkg/ccr/job_test.go
@@ -1309,7 +1309,7 @@ func TestHandleLightningSchemaChange(t *testing.T) {
 	defer ctrl.Finish()
 
 	// init data
-	testSql := fmt.Sprintf("`default_cluster:%s`.`%s` a test sql", tblSrcSpec.Database, tblSrcSpec.Table)
+	testSql := fmt.Sprintf("`%s`.`%s` a test sql", tblSrcSpec.Database, tblSrcSpec.Table)
 
 	// init db_mock
 	db := test_util.NewMockDB(ctrl)

--- a/pkg/ccr/meta.go
+++ b/pkg/ccr/meta.go
@@ -62,14 +62,14 @@ func (m *Meta) GetDbId() (int64, error) {
 		return dbId, nil
 	}
 
-	dbFullName := "default_cluster:" + dbName
+    dbFullName := "default_cluster:" + dbName
 	// mysql> show proc '/dbs/';
 	// +-------+------------------------------------+----------+----------+-------------+--------------------------+--------------+--------------+------------------+
 	// | DbId  | DbName                             | TableNum | Size     | Quota       | LastConsistencyCheckTime | ReplicaCount | ReplicaQuota | TransactionQuota |
 	// +-------+------------------------------------+----------+----------+-------------+--------------------------+--------------+--------------+------------------+
-	// | 0     | default_cluster:information_schema | 24       | 0.000    | 1024.000 TB | NULL                     | 0            | 1073741824   | 100              |
-	// | 10002 | default_cluster:__internal_schema  | 4        | 0.000    | 1024.000 TB | NULL                     | 28           | 1073741824   | 100              |
-	// | 10116 | default_cluster:ccr                | 2        | 2.738 KB | 1024.000 TB | NULL                     | 27           | 1073741824   | 100              |
+	// | 0     | information_schema | 24       | 0.000    | 1024.000 TB | NULL                     | 0            | 1073741824   | 100              |
+	// | 10002 | __internal_schema  | 4        | 0.000    | 1024.000 TB | NULL                     | 28           | 1073741824   | 100              |
+	// | 10116 | ccr                | 2        | 2.738 KB | 1024.000 TB | NULL                     | 27           | 1073741824   | 100              |
 	// +-------+------------------------------------+----------+----------+-------------+--------------------------+--------------+--------------+------------------+
 	db, err := m.Connect()
 	if err != nil {
@@ -98,7 +98,9 @@ func (m *Meta) GetDbId() (int64, error) {
 		}
 
 		// match parsedDbname == dbname, return dbId
-		if parsedDbName == dbFullName {
+		// the defualt_cluster prefix of db name will be removed in Doris v2.1.
+		// here we compare both db name and db full name to make it compatible.
+		if parsedDbName == dbName || parsedDbName == dbFullName {
 			m.DatabaseName2IdMap[dbFullName] = dbId
 			m.DatabaseMeta.Id = dbId
 			return dbId, nil

--- a/pkg/ccr/record/truncate_table.go
+++ b/pkg/ccr/record/truncate_table.go
@@ -9,7 +9,7 @@ import (
 
 // {
 //   "dbId": 10079,
-//   "db": "default_cluster:ccr",
+//   "db": "default_cluster:ccr", # "default_cluster:" prefix will be removed in Doris v2.1
 //   "tblId": 77395,
 //   "table": "src_1_alias",
 //   "isEntireTable": false,


### PR DESCRIPTION
The `default_cluster` prefix of db name will be removed in Doris v2.1.