### PR TITLE
get jobs from GetAllData

### DIFF
--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/selectdb/ccr_syncer/pkg/ccr"
@@ -485,16 +486,23 @@ func (s *HttpService) listJobsHandler(w http.ResponseWriter, r *http.Request) {
 	var jobResult *result
 	defer func() { writeJson(w, jobResult) }()
 
-	if _, jobs, err := s.db.GetStampAndJobs(s.hostInfo); err != nil {
-		log.Warnf("get jobs failed: %+v", err)
+	// use GetAllData to get all jobs
+	if ans, err := s.db.GetAllData(); err != nil {
+		log.Warnf("when list jobs, get all data failed: %+v", err)
 
 		jobResult = &result{
 			defaultResult: newErrorResult(err.Error()),
 		}
 	} else {
+		jobData := ans["jobs"]
+		allJobs := make([]string, 0)
+		for eachJob := range jobData {
+			allJobs = append(allJobs, strings.Trim(strings.Split(eachJob, ",")[0], " "))
+		}
+
 		jobResult = &result{
 			defaultResult: newSuccessResult(),
-			Jobs:          jobs,
+			Jobs:          allJobs,
 		}
 	}
 }

--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -494,9 +494,10 @@ func (s *HttpService) listJobsHandler(w http.ResponseWriter, r *http.Request) {
 			defaultResult: newErrorResult(err.Error()),
 		}
 	} else {
-		jobData := ans["jobs"]
+		var jobData []string
+		jobData = ans["jobs"]
 		allJobs := make([]string, 0)
-		for eachJob := range jobData {
+		for _, eachJob := range jobData {
 			allJobs = append(allJobs, strings.Trim(strings.Split(eachJob, ",")[0], " "))
 		}
 


### PR DESCRIPTION
When user use HA model, the meta data of syncer is stored in mysql or pg. User may use one syncer host to create job1, then create job2 by another syncer host. If user use a host ip to get all jobs' name, the interface will return only current host' jobs, rather than all jobs.