### PR TITLE
fix no lag when get_lag successed

### DIFF
--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -191,7 +191,7 @@ func (s *HttpService) getLagHandler(w http.ResponseWriter, r *http.Request) {
 
 	type result struct {
 		*defaultResult
-		Lag int64 `json:"lag,omitempty"`
+		Lag int64 `json:"lag"`
 	}
 	var lagResult *result
 	defer func() { writeJson(w, lagResult) }()


### PR DESCRIPTION
When query lag:
`curl -X POST -L --post303 -H "Content-Type: application/json" -d '{    "name": "job_name"}' http://ccr_syncer_host:ccr_syncer_port/get_lag`
if the lag is 0, the response is `{"success":true}` . The response is confusing.
 
Result `{"success":true,"lag":0}` is needed

