### PR TITLE
use full argument

### DIFF
--- a/cmd/snapshot_op/snapshot_op.go
+++ b/cmd/snapshot_op/snapshot_op.go
@@ -103,7 +103,7 @@ func test_restore_snapshot(src *base.Spec, dest *base.Spec) {
 	if err != nil {
 		panic(err)
 	}
-	restoreResp, err := destRpc.RestoreSnapshot(dest, nil, labelName, snapshotResp)
+	restoreResp, err := destRpc.RestoreSnapshot(dest, nil, labelName, snapshotResp, false, false)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Use a tool named 'govulncheck' to find vulnerabilities, it mentions that the method destRpc.RestoreSnapshot in cmd/snapshot_op/snapshot_op.go has insufficient arguments. So, just give the rest arguments.
