### PR TITLE
Fix commit txn for mow table

### DIFF
--- a/pkg/ccr/base/specer.go
+++ b/pkg/ccr/base/specer.go
@@ -28,7 +28,6 @@ type Specer interface {
 	CreateSnapshotAndWaitForDone(tables []string) (string, error)
 	CheckRestoreFinished(snapshotName string) (bool, error)
 	GetRestoreSignatureNotMatchedTable(snapshotName string) (string, error)
-	WaitTransactionDone(txnId int64) // busy wait
 
 	LightningSchemaChange(srcDatabase string, changes *record.ModifyTableAddOrDropColumns) error
 	TruncateTable(destTableName string, truncateTable *record.TruncateTable) error

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -1017,9 +1017,8 @@ func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 			break
 		}
 
-		if statusCode := resp.Status.GetStatusCode(); statusCode == tstatus.TStatusCode_PUBLISH_TIMEOUT {
-			dest.WaitTransactionDone(txnId)
-		} else if statusCode != tstatus.TStatusCode_OK {
+		statusCode := resp.Status.GetStatusCode()
+		if statusCode != tstatus.TStatusCode_OK && statusCode != tstatus.TStatusCode_PUBLISH_TIMEOUT {
 			err := xerror.Errorf(xerror.Normal, "commit txn failed, status: %v", resp.Status)
 			rollback(err, inMemoryData)
 			break


### PR DESCRIPTION
The version number of unique key mow table is strictly increasing. We just need to ensure that the txn status is `COMMITTED` instead of `VISIBLE`. Otherwise, binlog replay may loop endlessly for this txn.

ccr binlog replay error log: (**loop endlessly**)
```
ERROR wait transaction done failed, err +[normal] transaction 501 status: COMMITTED job=*** line=base/spec.go:798
```

dest doris cluster fe log: (**loop endlessly**)
```
WARN (thrift-server-pool-37|708) [MasterImpl.finishTask():94] finish task reports bad. request: TFinishTaskRequest(backend:TBackend(host:***, be_port:9060, http_port:8040), task_type:PUBLISH_VERSION, signature:501, task_status:TStatus(status_code:INTERNAL_ERROR, error_msgs:[(***)[E-3115]version not continuous for mow, tablet_id=15144, tablet_max_version=1037596, txn_version=1037627]), report_version:17244039530467, error_tablet_ids:[15028, 15036, 15044, 15048, 15056, 15064, 15068, 15076, 15084, 15088, 15096, 15104, 15108, 15116, 15124, 15128, 15136, 15144], succ_tablets:{}, table_id_to_delta_num_rows:{})
```

the status of txn 501 is forever `COMMITTED` with ErrMsg `wait for publishing partition 15027 version 1037597. self version: 1037627. table 15025`.