### PR TITLE
Fix error when hyphen in table name

### DIFF
--- a/pkg/ccr/base/spec.go
+++ b/pkg/ccr/base/spec.go
@@ -1038,4 +1038,3 @@ func correctAddPartitionSql(addPartitionSql string, addPartition *record.AddPart
 	}
 	return addPartitionSql
 }
-

--- a/pkg/ccr/base/spec.go
+++ b/pkg/ccr/base/spec.go
@@ -570,7 +570,7 @@ func (s *Spec) CreateSnapshotAndWaitForDone(tables []string) (string, error) {
 		return "", err
 	}
 
-	backupSnapshotSql := fmt.Sprintf("BACKUP SNAPSHOT %s.%s TO `__keep_on_local__` ON ( %s ) PROPERTIES (\"type\" = \"full\")", utils.FormatKeywordName(s.Database), snapshotName, tableRefs)
+	backupSnapshotSql := fmt.Sprintf("BACKUP SNAPSHOT %s.%s TO `__keep_on_local__` ON ( %s ) PROPERTIES (\"type\" = \"full\")", utils.FormatKeywordName(s.Database), utils.FormatKeywordName(snapshotName), tableRefs)
 	log.Debugf("backup snapshot sql: %s", backupSnapshotSql)
 	_, err = db.Exec(backupSnapshotSql)
 	if err != nil {
@@ -1038,3 +1038,4 @@ func correctAddPartitionSql(addPartitionSql string, addPartition *record.AddPart
 	}
 	return addPartitionSql
 }
+


### PR DESCRIPTION
When table name contains hyphen, backup job will return error. Because the name which contains hyphen should be enclosed