### PR TITLE
Fix create table failed message

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -1325,7 +1325,10 @@ func (j *Job) handleDropTable(binlog *festruct.TBinlog) error {
 	}
 
 	if err = j.IDest.DropTable(tableName, true); err != nil {
-		if !strings.Contains(err.Error(), "is not TABLE. Use 'DROP VIEW") {
+		// In apache/doris/common/ErrorCode.java
+		//
+		// ERR_WRONG_OBJECT(1347, new byte[]{'H', 'Y', '0', '0', '0'}, "'%s.%s' is not %s. %s.")
+		if !strings.Contains(err.Error(), "is not TABLE") {
 			return xerror.Wrapf(err, xerror.Normal, "drop table %s", tableName)
 		} else if err = j.IDest.DropView(tableName); err != nil { // retry with drop view.
 			return xerror.Wrapf(err, xerror.Normal, "drop view %s", tableName)

--- a/regression-test/suites/db-sync-view-drop-create/test_sync_view_drop_create.groovy
+++ b/regression-test/suites/db-sync-view-drop-create/test_sync_view_drop_create.groovy
@@ -16,12 +16,6 @@
 // under the License.
 
 suite("test_sync_view_drop_create") {
-    def versions = sql_return_maparray "show variables like 'version_comment'"
-    if (versions[0].Value.contains('doris-2.0.') || versions[0].Value.contains('doris-2.1.')) {
-        logger.info("2.0/2.1 not support this case, current version is: ${versions[0].Value}")
-        return
-    }
-
     def syncerAddress = "127.0.0.1:9190"
     def sync_gap_time = 5000
     def createDuplicateTable = { tableName ->

--- a/regression-test/suites/db-sync-view-drop-delete-create/test_sync_view_drop_delete_create.groovy
+++ b/regression-test/suites/db-sync-view-drop-delete-create/test_sync_view_drop_delete_create.groovy
@@ -16,12 +16,6 @@
 // under the License.
 
 suite("test_sync_view_drop_delete_create") {
-    def versions = sql_return_maparray "show variables like 'version_comment'"
-    if (versions[0].Value.contains('doris-2.0.') || versions[0].Value.contains('doris-2.1.')) {
-        logger.info("2.0/2.1 not support this case, current version is: ${versions[0].Value}")
-        return
-    }
-
     def syncerAddress = "127.0.0.1:9190"
     def sync_gap_time = 5000
     def createDuplicateTable = { tableName ->


### PR DESCRIPTION
In both doris 2.0/2.1, the ERR_WORING_OBJECT result didn't contains hint: "USE DROP VIEW".