### PR TITLE
Filter the committed binlogs

### DIFF
--- a/regression-test/common/helper.groovy
+++ b/regression-test/common/helper.groovy
@@ -220,6 +220,16 @@ class Helper {
         return false
     }
 
+    void force_fullsync(tableName = "") {
+        def bodyJson = suite.get_ccr_body "${table}"
+        suite.httpTest {
+            uri "/force_fullsync"
+            endpoint syncerAddress
+            body "${bodyJson}"
+            op "post"
+        }
+    }
+
     Object get_job_progress(tableName = "") {
         def request_body = suite.get_ccr_body(tableName)
         def get_job_progress_uri = { check_func ->

--- a/regression-test/suites/db-ps-inc/alter/test_db_partial_sync_inc_alter.groovy
+++ b/regression-test/suites/db-ps-inc/alter/test_db_partial_sync_inc_alter.groovy
@@ -1,0 +1,153 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_db_partial_sync_inc_alter") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    if (!helper.has_feature("feature_schema_change_partial_sync")) {
+        logger.info("this suite require feature_schema_change_partial_sync set to true")
+        return
+    }
+
+    def tableName = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def tableName1 = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def test_num = 0
+    def insert_num = 5
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+
+    def notExist = { res -> Boolean
+        return res.size() == 0
+    }
+
+    def has_count = { count ->
+        return { res -> Boolean
+            res.size() == count
+        }
+    }
+
+    helper.enableDbBinlog()
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        DUPLICATE KEY(`test`, `id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION p1 VALUES LESS THAN ("1000"),
+            PARTITION p2 VALUES LESS THAN ("2000"),
+            PARTITION p3 VALUES LESS THAN ("3000")
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    sql "DROP TABLE IF EXISTS ${tableName1}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName1}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        DUPLICATE KEY(`test`, `id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+
+    def values = [];
+    for (int index = 0; index < insert_num; index++) {
+        values.add("(${test_num}, ${index}, ${index})")
+    }
+    sql """
+        INSERT INTO ${tableName} VALUES ${values.join(",")}
+        """
+    sql """
+        INSERT INTO ${tableName1} VALUES ${values.join(",")}
+        """
+    sql "sync"
+
+    helper.ccrJobDelete()
+    helper.ccrJobCreate()
+
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 30))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num, 60))
+
+    def first_job_progress = helper.get_job_progress()
+
+    logger.info("=== pause job, add column and drop again")
+    helper.ccrJobPause()
+
+    sql """
+        ALTER TABLE ${tableName}
+        ADD COLUMN `first` INT KEY DEFAULT "0" FIRST
+        """
+    sql "sync"
+
+    assertTrue(helper.checkShowTimesOf("""
+                                SHOW ALTER TABLE COLUMN
+                                FROM ${context.dbName}
+                                WHERE TableName = "${tableName}" AND State = "FINISHED"
+                                """,
+                                has_count(1), 30))
+
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 1)"
+    sql "INSERT INTO ${tableName} VALUES (124, 124, 124, 2)"
+    sql "INSERT INTO ${tableName} VALUES (125, 125, 125, 3)"
+    sql "INSERT INTO ${tableName1} VALUES (123, 123, 1)"
+    sql "INSERT INTO ${tableName1} VALUES (124, 124, 2)"
+    sql "INSERT INTO ${tableName1} VALUES (125, 125, 3)"
+
+    sql """ ALTER TABLE ${tableName} DROP COLUMN `first` """
+    sql "sync"
+
+    assertTrue(helper.checkShowTimesOf("""
+                                SHOW ALTER TABLE COLUMN
+                                FROM ${context.dbName}
+                                WHERE TableName = "${tableName}" AND State = "FINISHED"
+                                """,
+                                has_count(2), 30))
+
+    helper.ccrJobResume()
+
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num + 3, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num + 3, 60))
+
+    sql "INSERT INTO ${tableName} VALUES (126, 126, 126)"
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num + 4, 60))
+
+    // no full sync triggered.
+    def last_job_progress = helper.get_job_progress()
+    assertTrue(last_job_progress.full_sync_start_at == first_job_progress.full_sync_start_at)
+}
+
+
+

--- a/regression-test/suites/db-ps-inc/drop_partition/test_db_partial_sync_inc_drop_partition.groovy
+++ b/regression-test/suites/db-ps-inc/drop_partition/test_db_partial_sync_inc_drop_partition.groovy
@@ -1,0 +1,152 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_db_partial_sync_inc_drop_partition") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    if (!helper.has_feature("feature_schema_change_partial_sync")) {
+        logger.info("this suite require feature_schema_change_partial_sync set to true")
+        return
+    }
+
+    def tableName = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def tableName1 = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def test_num = 0
+    def insert_num = 5
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+
+    def notExist = { res -> Boolean
+        return res.size() == 0
+    }
+
+    def has_count = { count ->
+        return { res -> Boolean
+            res.size() == count
+        }
+    }
+
+    helper.enableDbBinlog()
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`test`, `id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION p1 VALUES LESS THAN ("1000"),
+            PARTITION p2 VALUES LESS THAN ("2000"),
+            PARTITION p3 VALUES LESS THAN ("3000")
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    sql "DROP TABLE IF EXISTS ${tableName1}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName1}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`test`, `id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+
+    def values = [];
+    for (int index = 0; index < insert_num; index++) {
+        values.add("(${test_num}, ${index}, ${index})")
+    }
+    sql """
+        INSERT INTO ${tableName} VALUES ${values.join(",")}
+        """
+    sql """
+        INSERT INTO ${tableName1} VALUES ${values.join(",")}
+        """
+    sql "sync"
+
+    helper.ccrJobDelete()
+    helper.ccrJobCreate()
+
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 30))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num, 60))
+
+    def first_job_progress = helper.get_job_progress()
+
+    logger.info("=== pause job, add column and drop a partition")
+    helper.ccrJobPause()
+
+    sql """
+        ALTER TABLE ${tableName}
+        ADD COLUMN `first` INT KEY DEFAULT "0" FIRST
+        """
+    sql "sync"
+
+    assertTrue(helper.checkShowTimesOf("""
+                                SHOW ALTER TABLE COLUMN
+                                FROM ${context.dbName}
+                                WHERE TableName = "${tableName}" AND State = "FINISHED"
+                                """,
+                                has_count(1), 30))
+
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 1)"
+    sql "INSERT INTO ${tableName} VALUES (124, 124, 124, 2)"
+    sql "INSERT INTO ${tableName} VALUES (125, 125, 125, 3)"
+    sql "INSERT INTO ${tableName1} VALUES (123, 123, 1)"
+    sql "INSERT INTO ${tableName1} VALUES (124, 124, 2)"
+    sql "INSERT INTO ${tableName1} VALUES (125, 125, 3)"
+
+    sql """
+        ALTER TABLE ${tableName} DROP PARTITION p3
+        """
+
+    helper.ccrJobResume()
+
+    def has_column_first = { res -> Boolean
+        // Field == 'first' && 'Key' == 'YES'
+        return res[0][0] == 'first' && (res[0][3] == 'YES' || res[0][3] == 'true')
+    }
+
+    assertTrue(helper.checkShowTimesOf("SHOW COLUMNS FROM `${tableName}`", has_column_first, 60, "target_sql"))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num + 3, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num + 3, 60))
+    assertTrue(helper.checkShowTimesOf("SHOW PARTITIONS FROM ${tableName} WHERE PartitionName = \"p3\"", notExist, 60, "target_sql"))
+
+    sql "INSERT INTO ${tableName} VALUES (126, 126, 126, 4)"
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num + 4, 60))
+
+    // no full sync triggered.
+    def last_job_progress = helper.get_job_progress()
+    assertTrue(last_job_progress.full_sync_start_at == first_job_progress.full_sync_start_at)
+}
+

--- a/regression-test/suites/db-ps-inc/lightning_sc/test_db_partial_sync_inc_lightning_sc.groovy
+++ b/regression-test/suites/db-ps-inc/lightning_sc/test_db_partial_sync_inc_lightning_sc.groovy
@@ -1,0 +1,161 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_db_partial_sync_inc_lightning_sc") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    if (!helper.has_feature("feature_schema_change_partial_sync")) {
+        logger.info("this suite require feature_schema_change_partial_sync set to true")
+        return
+    }
+
+    def tableName = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def tableName1 = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def test_num = 0
+    def insert_num = 5
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+
+    def has_count = { count ->
+        return { res -> Boolean
+            res.size() == count
+        }
+    }
+
+    helper.enableDbBinlog()
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`test`, `id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION p1 VALUES LESS THAN ("1000"),
+            PARTITION p2 VALUES LESS THAN ("2000"),
+            PARTITION p3 VALUES LESS THAN ("3000")
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    sql "DROP TABLE IF EXISTS ${tableName1}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName1}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`test`, `id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+
+    def values = [];
+    for (int index = 0; index < insert_num; index++) {
+        values.add("(${test_num}, ${index}, ${index})")
+    }
+    sql """
+        INSERT INTO ${tableName} VALUES ${values.join(",")}
+        """
+    sql """
+        INSERT INTO ${tableName1} VALUES ${values.join(",")}
+        """
+    sql "sync"
+
+    helper.ccrJobDelete()
+    helper.ccrJobCreate()
+
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 30))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num, 60))
+
+    def first_job_progress = helper.get_job_progress()
+
+    logger.info("=== pause job, add column and add value column")
+    helper.ccrJobPause()
+
+    sql """
+        ALTER TABLE ${tableName}
+        ADD COLUMN `first` INT KEY DEFAULT "0" FIRST
+        """
+    sql "sync"
+
+    assertTrue(helper.checkShowTimesOf("""
+                                SHOW ALTER TABLE COLUMN
+                                FROM ${context.dbName}
+                                WHERE TableName = "${tableName}" AND State = "FINISHED"
+                                """,
+                                has_count(1), 30))
+
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 1)"
+    sql "INSERT INTO ${tableName} VALUES (124, 124, 124, 2)"
+    sql "INSERT INTO ${tableName} VALUES (125, 125, 125, 3)"
+    sql "INSERT INTO ${tableName1} VALUES (123, 123, 1)"
+    sql "INSERT INTO ${tableName1} VALUES (124, 124, 2)"
+    sql "INSERT INTO ${tableName1} VALUES (125, 125, 3)"
+
+    sql """
+        ALTER TABLE ${tableName}
+        ADD COLUMN `last` INT DEFAULT "0"
+        """
+
+    assertTrue(helper.checkShowTimesOf("""
+                                SHOW ALTER TABLE COLUMN
+                                FROM ${context.dbName}
+                                WHERE TableName = "${tableName}" AND State = "FINISHED"
+                                """,
+                                has_count(2), 30))
+
+    helper.ccrJobResume()
+
+    def has_column_first = { res -> Boolean
+        // Field == 'first' && 'Key' == 'YES'
+        return res[0][0] == 'first' && (res[0][3] == 'YES' || res[0][3] == 'true')
+    }
+
+    def has_column_last = { res -> Boolean
+        // Field == 'last' && 'Key' == 'NO'
+        return res[4][0] == 'last' && (res[4][3] == 'NO' || res[4][3] == 'false')
+    }
+
+    assertTrue(helper.checkShowTimesOf("SHOW COLUMNS FROM `${tableName}`", has_column_first, 60, "target_sql"))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num + 3, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num + 3, 60))
+    assertTrue(helper.checkShowTimesOf("SHOW COLUMNS FROM `${tableName}`", has_column_last, 60, "target_sql"))
+
+    sql "INSERT INTO ${tableName} VALUES (126, 126, 126, 4, 5)"
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num + 4, 60))
+
+    // no full sync triggered.
+    def last_job_progress = helper.get_job_progress()
+    assertTrue(last_job_progress.full_sync_start_at == first_job_progress.full_sync_start_at)
+}
+

--- a/regression-test/suites/db-ps-inc/merge/test_db_partial_sync_merge.groovy
+++ b/regression-test/suites/db-ps-inc/merge/test_db_partial_sync_merge.groovy
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_db_partial_sync_inc_merge") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    if (!helper.has_feature("feature_schema_change_partial_sync")) {
+        logger.info("this suite require feature_schema_change_partial_sync set to true")
+        return
+    }
+
+    def tableName = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def tableName1 = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def test_num = 0
+    def insert_num = 5
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+
+    def has_count = { count ->
+        return { res -> Boolean
+            res.size() == count
+        }
+    }
+
+    helper.enableDbBinlog()
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT SUM
+        )
+        ENGINE=OLAP
+        AGGREGATE KEY(`test`, `id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION p1 VALUES LESS THAN ("1000"),
+            PARTITION p2 VALUES LESS THAN ("2000"),
+            PARTITION p3 VALUES LESS THAN ("3000")
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    sql "DROP TABLE IF EXISTS ${tableName1}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName1}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT SUM
+        )
+        ENGINE=OLAP
+        AGGREGATE KEY(`test`, `id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+
+    def values = [];
+    for (int index = 0; index < insert_num; index++) {
+        values.add("(${test_num}, ${index}, ${index})")
+    }
+    sql """ INSERT INTO ${tableName} VALUES ${values.join(",")} """
+    sql """ INSERT INTO ${tableName1} VALUES ${values.join(",")} """
+    sql "sync"
+
+    helper.ccrJobDelete()
+    helper.ccrJobCreate()
+
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 30))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num, 60))
+
+    def first_job_progress = helper.get_job_progress()
+
+    // the change flow of the sync states:
+    //
+    //  db incremental sync                                         pause CCR job
+    //      -> db partial sync table A                              add column to A
+    //          -> db tables incremental with table A               insert some data into A
+    //              -> db partial sync table B                      add column to B
+    //                  -> db tables incremental with table A/B     insert some data into A/B, resume CCR job
+    //                      -> db incremental sync
+    helper.ccrJobPause()
+
+    sql """
+        ALTER TABLE ${tableName}
+        ADD COLUMN `first` INT KEY DEFAULT "0" FIRST
+        """
+    sql "sync"
+
+    assertTrue(helper.checkShowTimesOf("""
+                                SHOW ALTER TABLE COLUMN
+                                FROM ${context.dbName}
+                                WHERE TableName = "${tableName}" AND State = "FINISHED"
+                                """,
+                                has_count(1), 30))
+
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 1)"
+
+    sql """
+        ALTER TABLE ${tableName1}
+        ADD COLUMN `first` INT KEY DEFAULT "0" FIRST
+        """
+    sql "sync"
+
+    assertTrue(helper.checkShowTimesOf("""
+                                SHOW ALTER TABLE COLUMN
+                                FROM ${context.dbName}
+                                WHERE TableName = "${tableName1}" AND State = "FINISHED"
+                                """,
+                                has_count(1), 30))
+
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 2)"
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 3)"
+    sql "INSERT INTO ${tableName1} VALUES (123, 123, 123, 1)"
+    sql "INSERT INTO ${tableName1} VALUES (123, 123, 123, 2)"
+    sql "INSERT INTO ${tableName1} VALUES (123, 123, 123, 3)"
+
+    helper.ccrJobResume()
+
+    def has_column_first = { res -> Boolean
+        // Field == 'first' && 'Key' == 'YES'
+        return res[0][0] == 'first' && (res[0][3] == 'YES' || res[0][3] == 'true')
+    }
+
+    assertTrue(helper.checkShowTimesOf("SHOW COLUMNS FROM `${tableName}`", has_column_first, 60, "target_sql"))
+    assertTrue(helper.checkShowTimesOf("SHOW COLUMNS FROM `${tableName1}`", has_column_first, 60, "target_sql"))
+
+    logger.info("the aggregate keys inserted should be synced accurately")
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num + 1, 60))
+    def last_record = target_sql "SELECT value FROM ${tableName} WHERE id = 123 AND test = 123"
+    logger.info("last record is ${last_record}")
+    assertTrue(last_record.size() == 1 && last_record[0][0] == 6)
+
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num + 1, 60))
+    last_record = target_sql "SELECT value FROM ${tableName1} WHERE id = 123 AND test = 123"
+    logger.info("last record of table ${tableName1} is ${last_record}")
+    assertTrue(last_record.size() == 1 && last_record[0][0] == 6)
+
+    // no full sync triggered.
+    def last_job_progress = helper.get_job_progress()
+    assertTrue(last_job_progress.full_sync_start_at == first_job_progress.full_sync_start_at)
+}
+
+
+

--- a/regression-test/suites/db-ps-inc/replace_partition/test_db_partial_sync_inc_replace_partition.groovy
+++ b/regression-test/suites/db-ps-inc/replace_partition/test_db_partial_sync_inc_replace_partition.groovy
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_db_partial_sync_inc_replace_partition") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    if (!helper.has_feature("feature_schema_change_partial_sync")) {
+        logger.info("this suite require feature_schema_change_partial_sync set to true")
+        return
+    }
+
+    def tableName = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def tableName1 = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def test_num = 0
+    def insert_num = 5
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+
+    def has_count = { count ->
+        return { res -> Boolean
+            res.size() == count
+        }
+    }
+
+    helper.enableDbBinlog()
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`test`, `id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION p1 VALUES LESS THAN ("1000"),
+            PARTITION p2 VALUES LESS THAN ("2000"),
+            PARTITION p3 VALUES LESS THAN ("3000")
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    sql "DROP TABLE IF EXISTS ${tableName1}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName1}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`test`, `id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+
+    def values = [];
+    for (int index = 0; index < insert_num; index++) {
+        values.add("(${test_num}, ${index}, ${index})")
+    }
+    sql """
+        INSERT INTO ${tableName} VALUES ${values.join(",")}
+        """
+    sql """
+        INSERT INTO ${tableName1} VALUES ${values.join(",")}
+        """
+    sql "sync"
+
+    helper.ccrJobDelete()
+    helper.ccrJobCreate()
+
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 30))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num, 60))
+
+    def first_job_progress = helper.get_job_progress()
+
+    logger.info("=== pause job, add column and replace partition")
+    helper.ccrJobPause()
+
+    sql """
+        ALTER TABLE ${tableName}
+        ADD COLUMN `first` INT KEY DEFAULT "0" FIRST
+        """
+    sql "sync"
+
+    assertTrue(helper.checkShowTimesOf("""
+                                SHOW ALTER TABLE COLUMN
+                                FROM ${context.dbName}
+                                WHERE TableName = "${tableName}" AND State = "FINISHED"
+                                """,
+                                has_count(1), 30))
+
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 1)"
+    sql "INSERT INTO ${tableName} VALUES (124, 124, 124, 2)"
+    sql "INSERT INTO ${tableName} VALUES (125, 125, 125, 3)"
+    sql "INSERT INTO ${tableName1} VALUES (123, 123, 1)"
+    sql "INSERT INTO ${tableName1} VALUES (124, 124, 2)"
+    sql "INSERT INTO ${tableName1} VALUES (125, 125, 3)"
+
+    sql "ALTER TABLE ${tableName} ADD TEMPORARY PARTITION tp3 VALUES [(\"2000\"), (\"3000\"))"
+    sql "INSERT INTO ${tableName} TEMPORARY PARTITION (tp3) VALUES (2500, 2500, 2500, 1)"
+    sql "ALTER TABLE ${tableName} REPLACE PARTITION (p3) WITH TEMPORARY PARTITION (tp3)"
+
+    helper.ccrJobResume()
+
+    def has_column_first = { res -> Boolean
+        // Field == 'first' && 'Key' == 'YES'
+        return res[0][0] == 'first' && (res[0][3] == 'YES' || res[0][3] == 'true')
+    }
+
+    assertTrue(helper.checkShowTimesOf("SHOW COLUMNS FROM `${tableName}`", has_column_first, 60, "target_sql"))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num + 4, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num + 3, 60))
+
+    sql "INSERT INTO ${tableName} VALUES (126, 126, 126, 4)"
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num + 5, 60))
+
+    // no full sync triggered.
+    def last_job_progress = helper.get_job_progress()
+    assertTrue(last_job_progress.full_sync_start_at == first_job_progress.full_sync_start_at)
+}
+
+
+

--- a/regression-test/suites/db-ps-inc/truncate_table/test_db_partial_sync_inc_trunc_table.groovy
+++ b/regression-test/suites/db-ps-inc/truncate_table/test_db_partial_sync_inc_trunc_table.groovy
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_db_partial_sync_inc_trunc_table") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    if (!helper.has_feature("feature_schema_change_partial_sync")) {
+        logger.info("this suite require feature_schema_change_partial_sync set to true")
+        return
+    }
+
+    def tableName = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def tableName1 = "tbl_" + UUID.randomUUID().toString().replace("-", "")
+    def test_num = 0
+    def insert_num = 5
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+
+    def has_count = { count ->
+        return { res -> Boolean
+            res.size() == count
+        }
+    }
+
+    helper.enableDbBinlog()
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`test`, `id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION p1 VALUES LESS THAN ("1000"),
+            PARTITION p2 VALUES LESS THAN ("2000"),
+            PARTITION p3 VALUES LESS THAN ("3000")
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    sql "DROP TABLE IF EXISTS ${tableName1}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName1}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`test`, `id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+
+    def values = [];
+    for (int index = 0; index < insert_num; index++) {
+        values.add("(${test_num}, ${index}, ${index})")
+    }
+    sql """
+        INSERT INTO ${tableName} VALUES ${values.join(",")}
+        """
+    sql """
+        INSERT INTO ${tableName1} VALUES ${values.join(",")}
+        """
+    sql "sync"
+
+    helper.ccrJobDelete()
+    helper.ccrJobCreate()
+
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 30))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num, 60))
+
+    def first_job_progress = helper.get_job_progress()
+
+    logger.info("=== pause job, add column and truncate table")
+    helper.ccrJobPause()
+
+    sql """
+        ALTER TABLE ${tableName}
+        ADD COLUMN `first` INT KEY DEFAULT "0" FIRST
+        """
+    sql "sync"
+
+    assertTrue(helper.checkShowTimesOf("""
+                                SHOW ALTER TABLE COLUMN
+                                FROM ${context.dbName}
+                                WHERE TableName = "${tableName}" AND State = "FINISHED"
+                                """,
+                                has_count(1), 30))
+
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 1)"
+    sql "INSERT INTO ${tableName} VALUES (124, 124, 124, 2)"
+    sql "INSERT INTO ${tableName} VALUES (125, 125, 125, 3)"
+    sql "INSERT INTO ${tableName1} VALUES (123, 123, 1)"
+    sql "INSERT INTO ${tableName1} VALUES (124, 124, 2)"
+    sql "INSERT INTO ${tableName1} VALUES (125, 125, 3)"
+
+    sql "TRUNCATE TABLE ${tableName}"
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 1)"
+    sql "INSERT INTO ${tableName} VALUES (124, 124, 124, 2)"
+    sql "INSERT INTO ${tableName} VALUES (125, 125, 125, 3)"
+
+    helper.ccrJobResume()
+
+    def has_column_first = { res -> Boolean
+        // Field == 'first' && 'Key' == 'YES'
+        return res[0][0] == 'first' && (res[0][3] == 'YES' || res[0][3] == 'true')
+    }
+
+    assertTrue(helper.checkShowTimesOf("SHOW COLUMNS FROM `${tableName}`", has_column_first, 60, "target_sql"))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", 3, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num + 3, 60))
+
+    sql "INSERT INTO ${tableName} VALUES (126, 126, 126, 4)"
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", 4, 60))
+
+    // no full sync triggered.
+    def last_job_progress = helper.get_job_progress()
+    assertTrue(last_job_progress.full_sync_start_at == first_job_progress.full_sync_start_at)
+}
+
+

--- a/regression-test/suites/db-ps-inc/upsert/test_db_partial_sync_inc_upsert.groovy
+++ b/regression-test/suites/db-ps-inc/upsert/test_db_partial_sync_inc_upsert.groovy
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_db_partial_sync_inc_upsert") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    if (!helper.has_feature("feature_schema_change_partial_sync")) {
+        logger.info("this suite require feature_schema_change_partial_sync set to true")
+        return
+    }
+
+    def tableName = "tbl_sync_incremental_" + UUID.randomUUID().toString().replace("-", "")
+    def tableName1 = "tbl_sync_incremental_1_" + UUID.randomUUID().toString().replace("-", "")
+    def test_num = 0
+    def insert_num = 5
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+
+    def has_count = { count ->
+        return { res -> Boolean
+            res.size() == count
+        }
+    }
+
+    helper.enableDbBinlog()
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT SUM
+        )
+        ENGINE=OLAP
+        AGGREGATE KEY(`test`, `id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    sql "DROP TABLE IF EXISTS ${tableName1}"
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName1}
+        (
+            `test` INT,
+            `id` INT,
+            `value` INT SUM
+        )
+        ENGINE=OLAP
+        AGGREGATE KEY(`test`, `id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+
+    def values = [];
+    for (int index = 0; index < insert_num; index++) {
+        values.add("(${test_num}, ${index}, ${index})")
+    }
+    sql """
+        INSERT INTO ${tableName} VALUES ${values.join(",")}
+        """
+    sql """
+        INSERT INTO ${tableName1} VALUES ${values.join(",")}
+        """
+    sql "sync"
+
+    helper.ccrJobDelete()
+    helper.ccrJobCreate()
+
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 30))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num, 60))
+
+    def first_job_progress = helper.get_job_progress()
+
+    logger.info("=== pause job, add column and insert data")
+    helper.ccrJobPause()
+
+    // binlog type: ALTER_JOB, binlog data:
+    //  {
+    //      "type":"SCHEMA_CHANGE",
+    //      "dbId":11049,
+    //      "tableId":11058,
+    //      "tableName":"tbl_add_column6ab3b514b63c4368aa0a0149da0acabd",
+    //      "jobId":11076,
+    //      "jobState":"FINISHED",
+    //      "rawSql":"ALTER TABLE `regression_test_schema_change`.`tbl_add_column6ab3b514b63c4368aa0a0149da0acabd` ADD COLUMN `first` int NULL DEFAULT \"0\" COMMENT \"\" FIRST"
+    //  }
+    sql """
+        ALTER TABLE ${tableName}
+        ADD COLUMN `first` INT KEY DEFAULT "0" FIRST
+        """
+    sql "sync"
+
+    assertTrue(helper.checkShowTimesOf("""
+                                SHOW ALTER TABLE COLUMN
+                                FROM ${context.dbName}
+                                WHERE TableName = "${tableName}" AND State = "FINISHED"
+                                """,
+                                has_count(1), 30))
+
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 1)"
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 2)"
+    sql "INSERT INTO ${tableName} VALUES (123, 123, 123, 3)"
+    sql "INSERT INTO ${tableName1} VALUES (123, 123, 1)"
+    sql "INSERT INTO ${tableName1} VALUES (123, 123, 2)"
+    sql "INSERT INTO ${tableName1} VALUES (123, 123, 3)"
+
+    helper.ccrJobResume()
+
+    def has_column_first = { res -> Boolean
+        // Field == 'first' && 'Key' == 'YES'
+        return res[0][0] == 'first' && (res[0][3] == 'YES' || res[0][3] == 'true')
+    }
+
+    assertTrue(helper.checkShowTimesOf("SHOW COLUMNS FROM `${tableName}`", has_column_first, 60, "target_sql"))
+
+    logger.info("the aggregate keys inserted should be synced accurately")
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", insert_num + 1, 60))
+    def last_record = target_sql "SELECT value FROM ${tableName} WHERE id = 123 AND test = 123"
+    logger.info("last record is ${last_record}")
+    assertTrue(last_record.size() == 1 && last_record[0][0] == 6)
+
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", insert_num + 1, 60))
+    last_record = target_sql "SELECT value FROM ${tableName1} WHERE id = 123 AND test = 123"
+    logger.info("last record of table ${tableName1} is ${last_record}")
+    assertTrue(last_record.size() == 1 && last_record[0][0] == 6)
+
+    // no full sync triggered.
+    def last_job_progress = helper.get_job_progress()
+    assertTrue(last_job_progress.full_sync_start_at == first_job_progress.full_sync_start_at)
+}
+
+
+
+


### PR DESCRIPTION
Partial sync will cause some binlogs to be skipped by snapshot, but the commit seq is updated (because the binlogs of other tables haven't been synchronized yet). Therefore, for binlogs of types other than upsert, it is also necessary to determine whether they have been synchronized.