### PR TITLE
Build table mapping from snapshot job info

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -633,6 +633,7 @@ func (j *Job) fullSync() error {
 		SnapshotName      string                        `json:"snapshot_name"`
 		SnapshotResp      *festruct.TGetSnapshotResult_ `json:"snapshot_resp"`
 		TableCommitSeqMap map[int64]int64               `json:"table_commit_seq_map"`
+		TableNameMapping  map[int64]string              `json:"table_name_mapping"`
 		RestoreLabel      string                        `json:"restore_label"`
 	}
 
@@ -721,6 +722,11 @@ func (j *Job) fullSync() error {
 			return err
 		}
 
+		tableMapping, err := ExtractTableMapping(snapshotResp.GetJobInfo())
+		if err != nil {
+			return err
+		}
+
 		if j.SyncType == TableSync {
 			if _, ok := tableCommitSeqMap[j.Src.TableId]; !ok {
 				return xerror.Errorf(xerror.Normal, "table id %d, commit seq not found", j.Src.TableId)
@@ -731,6 +737,7 @@ func (j *Job) fullSync() error {
 			SnapshotName:      snapshotName,
 			SnapshotResp:      snapshotResp,
 			TableCommitSeqMap: tableCommitSeqMap,
+			TableNameMapping:  tableMapping,
 		}
 		j.progress.NextSubVolatile(AddExtraInfo, inMemoryData)
 
@@ -779,6 +786,7 @@ func (j *Job) fullSync() error {
 		snapshotName := inMemoryData.SnapshotName
 		restoreSnapshotName := restoreSnapshotName(snapshotName)
 		snapshotResp := inMemoryData.SnapshotResp
+		tableNameMapping := inMemoryData.TableNameMapping
 
 		// Step 5.3: restore snapshot to dest
 		dest := &j.Dest
@@ -903,6 +911,7 @@ func (j *Job) fullSync() error {
 					commitSeq = utils.Min(commitSeq, seq)
 				}
 				j.progress.TableCommitSeqMap = tableCommitSeqMap // persist in CommitNext
+				j.progress.TableNameMapping = tableNameMapping
 			case TableSync:
 				commitSeq = tableCommitSeqMap[j.Src.TableId]
 			}
@@ -958,16 +967,24 @@ func (j *Job) fullSync() error {
 			j.destMeta.ClearTablesCache()
 			tableMapping := make(map[int64]int64)
 			for srcTableId := range j.progress.TableCommitSeqMap {
-				srcTableName, err := j.srcMeta.GetTableNameById(srcTableId)
-				if err != nil {
-					return err
-				}
+				var srcTableName string
+				if name, ok := j.progress.TableNameMapping[srcTableId]; ok {
+					srcTableName = name
+				} else {
+					// Keep compatible, but once the upstream table is renamed, the
+					// downstream table id will not be found here.
+					name, err := j.srcMeta.GetTableNameById(srcTableId)
+					if err != nil {
+						return err
+					}
+					srcTableName = name
 
-				// If srcTableName is empty, it may be deleted.
-				// No need to map it to dest table
-				if srcTableName == "" {
-					log.Warnf("the name of source table id: %d is empty, no need to map it to dest table", srcTableId)
-					continue
+					// If srcTableName is empty, it may be deleted.
+					// No need to map it to dest table
+					if srcTableName == "" {
+						log.Warnf("the name of source table id: %d is empty, no need to map it to dest table", srcTableId)
+						continue
+					}
 				}
 
 				destTableId, err := j.destMeta.GetTableId(srcTableName)

--- a/pkg/ccr/job_progress.go
+++ b/pkg/ccr/job_progress.go
@@ -152,9 +152,12 @@ type JobProgress struct {
 	SubSyncState SubSyncState `json:"sub_sync_state"`
 
 	// The commit seq where the target cluster has synced.
-	PrevCommitSeq     int64               `json:"prev_commit_seq"`
-	CommitSeq         int64               `json:"commit_seq"`
-	TableMapping      map[int64]int64     `json:"table_mapping"`
+	PrevCommitSeq int64           `json:"prev_commit_seq"`
+	CommitSeq     int64           `json:"commit_seq"`
+	TableMapping  map[int64]int64 `json:"table_mapping"`
+	// the upstream table id to name mapping, build during the fullsync,
+	// keep snapshot to avoid rename. it might be staled.
+	TableNameMapping  map[int64]string    `json:"table_name_mapping"`
 	TableCommitSeqMap map[int64]int64     `json:"table_commit_seq_map"` // only for DBTablesIncrementalSync
 	InMemoryData      any                 `json:"-"`
 	PersistData       string              `json:"data"` // this often for binlog or snapshot info

--- a/pkg/ccr/utils.go
+++ b/pkg/ccr/utils.go
@@ -13,7 +13,27 @@ func ExtractTableCommitSeqMap(data []byte) (map[int64]int64, error) {
 	var jobInfo JobInfo
 
 	if err := json.Unmarshal(data, &jobInfo); err != nil {
-		return nil, xerror.Wrapf(err, xerror.Normal, "unmarshal job info error: %v", err)
+		return nil, xerror.Wrapf(err, xerror.Normal, "unmarshal job info for extracting table commit seq map error: %v", err)
 	}
 	return jobInfo.TableCommitSeqMap, nil
+}
+
+func ExtractTableMapping(data []byte) (map[int64]string, error) {
+	type BackupOlapTableInfo struct {
+		Id int64 `json:"id"`
+	}
+	type JobInfo struct {
+		BackupObjects map[string]BackupOlapTableInfo `json:"backup_objects"`
+	}
+
+	var jobInfo JobInfo
+	if err := json.Unmarshal(data, &jobInfo); err != nil {
+		return nil, xerror.Wrapf(err, xerror.Normal, "unmarshal job info for extracting table mapping error: %v", err)
+	}
+
+	tableMapping := make(map[int64]string)
+	for tableName, tableInfo := range jobInfo.BackupObjects {
+		tableMapping[tableInfo.Id] = tableName
+	}
+	return tableMapping, nil
 }


### PR DESCRIPTION
The upstream may rename the tables associated with the backup job. Consequently, when the restore job is completed, the downstream table won't be located when establishing the table mapping. This PR stores the table name mapping from the snapshot job information, thus preventing the need to read from the upstream.