### PR TITLE
Fix infinite loop when backup/restore job failed

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -382,6 +382,7 @@ func (j *Job) partialSync() error {
 		snapshotName := j.progress.InMemoryData.(string)
 		backupFinished, err := j.ISrc.CheckBackupFinished(snapshotName)
 		if err != nil {
+			j.progress.NextSubVolatile(BeginCreateSnapshot, snapshotName)
 			return err
 		}
 
@@ -547,6 +548,7 @@ func (j *Job) partialSync() error {
 
 		restoreFinished, err := j.IDest.CheckRestoreFinished(restoreSnapshotName)
 		if err != nil {
+			j.progress.NextSubVolatile(RestoreSnapshot, inMemoryData)
 			return err
 		}
 
@@ -680,6 +682,7 @@ func (j *Job) fullSync() error {
 		snapshotName := j.progress.InMemoryData.(string)
 		backupFinished, err := j.ISrc.CheckBackupFinished(snapshotName)
 		if err != nil {
+			j.progress.NextSubVolatile(BeginCreateSnapshot, snapshotName)
 			return err
 		}
 		if !backupFinished {
@@ -887,6 +890,7 @@ func (j *Job) fullSync() error {
 				log.Infof("the restore is cancelled, the unmatched %s %s is dropped, restore snapshot again", resource, tableName)
 				break
 			} else if err != nil {
+				j.progress.NextSubVolatile(RestoreSnapshot, inMemoryData)
 				return err
 			}
 


### PR DESCRIPTION
When the backup/restore job failed, the state should be reset to create backup/restore again.