### PR TITLE
Support compressed snapshot to avoid thrift max message size limitation

### DIFF
--- a/pkg/ccr/base/specer.go
+++ b/pkg/ccr/base/specer.go
@@ -17,6 +17,7 @@ type Specer interface {
 	Valid() error
 	IsDatabaseEnableBinlog() (bool, error)
 	IsTableEnableBinlog() (bool, error)
+	IsEnableRestoreSnapshotCompression() (bool, error)
 	GetAllTables() ([]string, error)
 	GetAllViewsFromTable(tableName string) ([]string, error)
 	ClearDB() error

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -43,6 +43,7 @@ var (
 	featureReplaceNotMatchedWithAlias   bool
 	featureFilterShadowIndexesUpsert    bool
 	featureReuseRunningBackupRestoreJob bool
+	featureCompressedSnapshot           bool
 )
 
 func init() {
@@ -62,6 +63,8 @@ func init() {
 		"filter the upsert to the shadow indexes")
 	flag.BoolVar(&featureReuseRunningBackupRestoreJob, "feature_reuse_running_backup_restore_job", false,
 		"reuse the running backup/restore issued by the job self")
+	flag.BoolVar(&featureCompressedSnapshot, "feature_compressed_snapshot", true,
+		"compress the snapshot job info and meta")
 }
 
 type SyncType int
@@ -414,7 +417,8 @@ func (j *Job) partialSync() error {
 		}
 
 		log.Debugf("partial sync begin get snapshot %s", snapshotName)
-		snapshotResp, err := srcRpc.GetSnapshot(src, snapshotName)
+		compress := false // partial snapshot no need to compress
+		snapshotResp, err := srcRpc.GetSnapshot(src, snapshotName, compress)
 		if err != nil {
 			return err
 		}
@@ -545,6 +549,7 @@ func (j *Job) partialSync() error {
 			CleanPartitions: false,
 			CleanTables:     false,
 			AtomicRestore:   false,
+			Compress:        false,
 		}
 		restoreResp, err := destRpc.RestoreSnapshot(dest, &restoreReq)
 		if err != nil {
@@ -736,7 +741,8 @@ func (j *Job) fullSync() error {
 		}
 
 		log.Debugf("fullsync begin get snapshot %s", snapshotName)
-		snapshotResp, err := srcRpc.GetSnapshot(src, snapshotName)
+		compress := false
+		snapshotResp, err := srcRpc.GetSnapshot(src, snapshotName, compress)
 		if err != nil {
 			return err
 		}
@@ -746,11 +752,24 @@ func (j *Job) fullSync() error {
 			return err
 		}
 
-		log.Tracef("fullsync snapshot job: %.128s", snapshotResp.GetJobInfo())
 		if !snapshotResp.IsSetJobInfo() {
 			return xerror.New(xerror.Normal, "jobInfo is not set")
 		}
 
+		if snapshotResp.GetCompressed() {
+			if bytes, err := utils.GZIPDecompress(snapshotResp.GetJobInfo()); err != nil {
+				return xerror.Wrap(err, xerror.Normal, "decompress snapshot job info failed")
+			} else {
+				snapshotResp.SetJobInfo(bytes)
+			}
+			if bytes, err := utils.GZIPDecompress(snapshotResp.GetMeta()); err != nil {
+				return xerror.Wrap(err, xerror.Normal, "decompress snapshot meta failed")
+			} else {
+				snapshotResp.SetMeta(bytes)
+			}
+		}
+
+		log.Tracef("fullsync snapshot job: %.128s", snapshotResp.GetJobInfo())
 		backupJobInfo, err := NewBackupJobInfoFromJson(snapshotResp.GetJobInfo())
 		if err != nil {
 			return err
@@ -872,6 +891,14 @@ func (j *Job) fullSync() error {
 			}
 		}
 
+		compress := false
+		if featureCompressedSnapshot {
+			if enable, err := j.IDest.IsEnableRestoreSnapshotCompression(); err != nil {
+				return xerror.Wrap(err, xerror.Normal, "check enable restore snapshot compression failed")
+			} else {
+				compress = enable
+			}
+		}
 		restoreReq := rpc.RestoreSnapshotRequest{
 			TableRefs:       tableRefs,
 			SnapshotName:    restoreSnapshotName,
@@ -879,6 +906,7 @@ func (j *Job) fullSync() error {
 			CleanPartitions: false,
 			CleanTables:     false,
 			AtomicRestore:   false,
+			Compress:        compress,
 		}
 		if featureCleanTableAndPartitions {
 			// drop exists partitions, and drop tables if in db sync.
@@ -956,7 +984,7 @@ func (j *Job) fullSync() error {
 			}
 
 			if !restoreFinished {
-				log.Info("fullsync status: restore job %s is running", restoreSnapshotName)
+				log.Infof("fullsync status: restore job %s is running", restoreSnapshotName)
 				return nil
 			}
 

--- a/pkg/ccr/job_progress.go
+++ b/pkg/ccr/job_progress.go
@@ -159,7 +159,7 @@ type JobProgress struct {
 	TableMapping  map[int64]int64 `json:"table_mapping"`
 	// the upstream table id to name mapping, build during the fullsync,
 	// keep snapshot to avoid rename. it might be staled.
-	TableNameMapping  map[int64]string    `json:"table_name_mapping"`
+	TableNameMapping  map[int64]string    `json:"table_name_mapping,omitempty"`
 	TableCommitSeqMap map[int64]int64     `json:"table_commit_seq_map"` // only for DBTablesIncrementalSync
 	InMemoryData      any                 `json:"-"`
 	PersistData       string              `json:"data"` // this often for binlog or snapshot info

--- a/pkg/ccr/job_progress_test.go
+++ b/pkg/ccr/job_progress_test.go
@@ -70,6 +70,7 @@ func TestJobProgress_MarshalJSON(t *testing.T) {
     "state": 0,
     "binlog_type": -1
   },
+  "job_sync_id":0,
   "prev_commit_seq": 0,
   "commit_seq": 1,
   "table_mapping": null,

--- a/pkg/rpc/kitex_gen/data/Data.go
+++ b/pkg/rpc/kitex_gen/data/Data.go
@@ -600,6 +600,7 @@ type TCell struct {
 	LongVal   *int64   `thrift:"longVal,3,optional" frugal:"3,optional,i64" json:"longVal,omitempty"`
 	DoubleVal *float64 `thrift:"doubleVal,4,optional" frugal:"4,optional,double" json:"doubleVal,omitempty"`
 	StringVal *string  `thrift:"stringVal,5,optional" frugal:"5,optional,string" json:"stringVal,omitempty"`
+	IsNull    *bool    `thrift:"isNull,6,optional" frugal:"6,optional,bool" json:"isNull,omitempty"`
 }
 
 func NewTCell() *TCell {
@@ -653,6 +654,15 @@ func (p *TCell) GetStringVal() (v string) {
 	}
 	return *p.StringVal
 }
+
+var TCell_IsNull_DEFAULT bool
+
+func (p *TCell) GetIsNull() (v bool) {
+	if !p.IsSetIsNull() {
+		return TCell_IsNull_DEFAULT
+	}
+	return *p.IsNull
+}
 func (p *TCell) SetBoolVal(val *bool) {
 	p.BoolVal = val
 }
@@ -668,6 +678,9 @@ func (p *TCell) SetDoubleVal(val *float64) {
 func (p *TCell) SetStringVal(val *string) {
 	p.StringVal = val
 }
+func (p *TCell) SetIsNull(val *bool) {
+	p.IsNull = val
+}
 
 var fieldIDToName_TCell = map[int16]string{
 	1: "boolVal",
@@ -675,6 +688,7 @@ var fieldIDToName_TCell = map[int16]string{
 	3: "longVal",
 	4: "doubleVal",
 	5: "stringVal",
+	6: "isNull",
 }
 
 func (p *TCell) IsSetBoolVal() bool {
@@ -695,6 +709,10 @@ func (p *TCell) IsSetDoubleVal() bool {
 
 func (p *TCell) IsSetStringVal() bool {
 	return p.StringVal != nil
+}
+
+func (p *TCell) IsSetIsNull() bool {
+	return p.IsNull != nil
 }
 
 func (p *TCell) Read(iprot thrift.TProtocol) (err error) {
@@ -751,6 +769,14 @@ func (p *TCell) Read(iprot thrift.TProtocol) (err error) {
 		case 5:
 			if fieldTypeId == thrift.STRING {
 				if err = p.ReadField5(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 6:
+			if fieldTypeId == thrift.BOOL {
+				if err = p.ReadField6(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -840,6 +866,17 @@ func (p *TCell) ReadField5(iprot thrift.TProtocol) error {
 	p.StringVal = _field
 	return nil
 }
+func (p *TCell) ReadField6(iprot thrift.TProtocol) error {
+
+	var _field *bool
+	if v, err := iprot.ReadBool(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.IsNull = _field
+	return nil
+}
 
 func (p *TCell) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -865,6 +902,10 @@ func (p *TCell) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField5(oprot); err != nil {
 			fieldId = 5
+			goto WriteFieldError
+		}
+		if err = p.writeField6(oprot); err != nil {
+			fieldId = 6
 			goto WriteFieldError
 		}
 	}
@@ -980,6 +1021,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 5 end error: ", p), err)
 }
 
+func (p *TCell) writeField6(oprot thrift.TProtocol) (err error) {
+	if p.IsSetIsNull() {
+		if err = oprot.WriteFieldBegin("isNull", thrift.BOOL, 6); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteBool(*p.IsNull); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 6 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 6 end error: ", p), err)
+}
+
 func (p *TCell) String() string {
 	if p == nil {
 		return "<nil>"
@@ -1007,6 +1067,9 @@ func (p *TCell) DeepEqual(ano *TCell) bool {
 		return false
 	}
 	if !p.Field5DeepEqual(ano.StringVal) {
+		return false
+	}
+	if !p.Field6DeepEqual(ano.IsNull) {
 		return false
 	}
 	return true
@@ -1068,6 +1131,18 @@ func (p *TCell) Field5DeepEqual(src *string) bool {
 		return false
 	}
 	if strings.Compare(*p.StringVal, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TCell) Field6DeepEqual(src *bool) bool {
+
+	if p.IsNull == src {
+		return true
+	} else if p.IsNull == nil || src == nil {
+		return false
+	}
+	if *p.IsNull != *src {
 		return false
 	}
 	return true

--- a/pkg/rpc/kitex_gen/descriptors/Descriptors.go
+++ b/pkg/rpc/kitex_gen/descriptors/Descriptors.go
@@ -6245,12 +6245,13 @@ func (p *TOlapTablePartitionParam) Field13DeepEqual(src bool) bool {
 }
 
 type TOlapTableIndex struct {
-	IndexName  *string           `thrift:"index_name,1,optional" frugal:"1,optional,string" json:"index_name,omitempty"`
-	Columns    []string          `thrift:"columns,2,optional" frugal:"2,optional,list<string>" json:"columns,omitempty"`
-	IndexType  *TIndexType       `thrift:"index_type,3,optional" frugal:"3,optional,TIndexType" json:"index_type,omitempty"`
-	Comment    *string           `thrift:"comment,4,optional" frugal:"4,optional,string" json:"comment,omitempty"`
-	IndexId    *int64            `thrift:"index_id,5,optional" frugal:"5,optional,i64" json:"index_id,omitempty"`
-	Properties map[string]string `thrift:"properties,6,optional" frugal:"6,optional,map<string:string>" json:"properties,omitempty"`
+	IndexName       *string           `thrift:"index_name,1,optional" frugal:"1,optional,string" json:"index_name,omitempty"`
+	Columns         []string          `thrift:"columns,2,optional" frugal:"2,optional,list<string>" json:"columns,omitempty"`
+	IndexType       *TIndexType       `thrift:"index_type,3,optional" frugal:"3,optional,TIndexType" json:"index_type,omitempty"`
+	Comment         *string           `thrift:"comment,4,optional" frugal:"4,optional,string" json:"comment,omitempty"`
+	IndexId         *int64            `thrift:"index_id,5,optional" frugal:"5,optional,i64" json:"index_id,omitempty"`
+	Properties      map[string]string `thrift:"properties,6,optional" frugal:"6,optional,map<string:string>" json:"properties,omitempty"`
+	ColumnUniqueIds []int32           `thrift:"column_unique_ids,7,optional" frugal:"7,optional,list<i32>" json:"column_unique_ids,omitempty"`
 }
 
 func NewTOlapTableIndex() *TOlapTableIndex {
@@ -6313,6 +6314,15 @@ func (p *TOlapTableIndex) GetProperties() (v map[string]string) {
 	}
 	return p.Properties
 }
+
+var TOlapTableIndex_ColumnUniqueIds_DEFAULT []int32
+
+func (p *TOlapTableIndex) GetColumnUniqueIds() (v []int32) {
+	if !p.IsSetColumnUniqueIds() {
+		return TOlapTableIndex_ColumnUniqueIds_DEFAULT
+	}
+	return p.ColumnUniqueIds
+}
 func (p *TOlapTableIndex) SetIndexName(val *string) {
 	p.IndexName = val
 }
@@ -6331,6 +6341,9 @@ func (p *TOlapTableIndex) SetIndexId(val *int64) {
 func (p *TOlapTableIndex) SetProperties(val map[string]string) {
 	p.Properties = val
 }
+func (p *TOlapTableIndex) SetColumnUniqueIds(val []int32) {
+	p.ColumnUniqueIds = val
+}
 
 var fieldIDToName_TOlapTableIndex = map[int16]string{
 	1: "index_name",
@@ -6339,6 +6352,7 @@ var fieldIDToName_TOlapTableIndex = map[int16]string{
 	4: "comment",
 	5: "index_id",
 	6: "properties",
+	7: "column_unique_ids",
 }
 
 func (p *TOlapTableIndex) IsSetIndexName() bool {
@@ -6363,6 +6377,10 @@ func (p *TOlapTableIndex) IsSetIndexId() bool {
 
 func (p *TOlapTableIndex) IsSetProperties() bool {
 	return p.Properties != nil
+}
+
+func (p *TOlapTableIndex) IsSetColumnUniqueIds() bool {
+	return p.ColumnUniqueIds != nil
 }
 
 func (p *TOlapTableIndex) Read(iprot thrift.TProtocol) (err error) {
@@ -6427,6 +6445,14 @@ func (p *TOlapTableIndex) Read(iprot thrift.TProtocol) (err error) {
 		case 6:
 			if fieldTypeId == thrift.MAP {
 				if err = p.ReadField6(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 7:
+			if fieldTypeId == thrift.LIST {
+				if err = p.ReadField7(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -6558,6 +6584,29 @@ func (p *TOlapTableIndex) ReadField6(iprot thrift.TProtocol) error {
 	p.Properties = _field
 	return nil
 }
+func (p *TOlapTableIndex) ReadField7(iprot thrift.TProtocol) error {
+	_, size, err := iprot.ReadListBegin()
+	if err != nil {
+		return err
+	}
+	_field := make([]int32, 0, size)
+	for i := 0; i < size; i++ {
+
+		var _elem int32
+		if v, err := iprot.ReadI32(); err != nil {
+			return err
+		} else {
+			_elem = v
+		}
+
+		_field = append(_field, _elem)
+	}
+	if err := iprot.ReadListEnd(); err != nil {
+		return err
+	}
+	p.ColumnUniqueIds = _field
+	return nil
+}
 
 func (p *TOlapTableIndex) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -6587,6 +6636,10 @@ func (p *TOlapTableIndex) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField6(oprot); err != nil {
 			fieldId = 6
+			goto WriteFieldError
+		}
+		if err = p.writeField7(oprot); err != nil {
+			fieldId = 7
 			goto WriteFieldError
 		}
 	}
@@ -6740,6 +6793,33 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 6 end error: ", p), err)
 }
 
+func (p *TOlapTableIndex) writeField7(oprot thrift.TProtocol) (err error) {
+	if p.IsSetColumnUniqueIds() {
+		if err = oprot.WriteFieldBegin("column_unique_ids", thrift.LIST, 7); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteListBegin(thrift.I32, len(p.ColumnUniqueIds)); err != nil {
+			return err
+		}
+		for _, v := range p.ColumnUniqueIds {
+			if err := oprot.WriteI32(v); err != nil {
+				return err
+			}
+		}
+		if err := oprot.WriteListEnd(); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 7 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 7 end error: ", p), err)
+}
+
 func (p *TOlapTableIndex) String() string {
 	if p == nil {
 		return "<nil>"
@@ -6770,6 +6850,9 @@ func (p *TOlapTableIndex) DeepEqual(ano *TOlapTableIndex) bool {
 		return false
 	}
 	if !p.Field6DeepEqual(ano.Properties) {
+		return false
+	}
+	if !p.Field7DeepEqual(ano.ColumnUniqueIds) {
 		return false
 	}
 	return true
@@ -6844,6 +6927,19 @@ func (p *TOlapTableIndex) Field6DeepEqual(src map[string]string) bool {
 	for k, v := range p.Properties {
 		_src := src[k]
 		if strings.Compare(v, _src) != 0 {
+			return false
+		}
+	}
+	return true
+}
+func (p *TOlapTableIndex) Field7DeepEqual(src []int32) bool {
+
+	if len(p.ColumnUniqueIds) != len(src) {
+		return false
+	}
+	for i, v := range p.ColumnUniqueIds {
+		_src := src[i]
+		if v != _src {
 			return false
 		}
 	}
@@ -7452,6 +7548,8 @@ type TOlapTableSchemaParam struct {
 	AutoIncrementColumn            *string                               `thrift:"auto_increment_column,11,optional" frugal:"11,optional,string" json:"auto_increment_column,omitempty"`
 	AutoIncrementColumnUniqueId    int32                                 `thrift:"auto_increment_column_unique_id,12,optional" frugal:"12,optional,i32" json:"auto_increment_column_unique_id,omitempty"`
 	InvertedIndexFileStorageFormat types.TInvertedIndexFileStorageFormat `thrift:"inverted_index_file_storage_format,13,optional" frugal:"13,optional,TInvertedIndexFileStorageFormat" json:"inverted_index_file_storage_format,omitempty"`
+	UniqueKeyUpdateMode            *types.TUniqueKeyUpdateMode           `thrift:"unique_key_update_mode,14,optional" frugal:"14,optional,TUniqueKeyUpdateMode" json:"unique_key_update_mode,omitempty"`
+	SequenceMapColUniqueId         int32                                 `thrift:"sequence_map_col_unique_id,15,optional" frugal:"15,optional,i32" json:"sequence_map_col_unique_id,omitempty"`
 }
 
 func NewTOlapTableSchemaParam() *TOlapTableSchemaParam {
@@ -7460,6 +7558,7 @@ func NewTOlapTableSchemaParam() *TOlapTableSchemaParam {
 		IsStrictMode:                   false,
 		AutoIncrementColumnUniqueId:    -1,
 		InvertedIndexFileStorageFormat: types.TInvertedIndexFileStorageFormat_V1,
+		SequenceMapColUniqueId:         -1,
 	}
 }
 
@@ -7467,6 +7566,7 @@ func (p *TOlapTableSchemaParam) InitDefault() {
 	p.IsStrictMode = false
 	p.AutoIncrementColumnUniqueId = -1
 	p.InvertedIndexFileStorageFormat = types.TInvertedIndexFileStorageFormat_V1
+	p.SequenceMapColUniqueId = -1
 }
 
 func (p *TOlapTableSchemaParam) GetDbId() (v int64) {
@@ -7560,6 +7660,24 @@ func (p *TOlapTableSchemaParam) GetInvertedIndexFileStorageFormat() (v types.TIn
 	}
 	return p.InvertedIndexFileStorageFormat
 }
+
+var TOlapTableSchemaParam_UniqueKeyUpdateMode_DEFAULT types.TUniqueKeyUpdateMode
+
+func (p *TOlapTableSchemaParam) GetUniqueKeyUpdateMode() (v types.TUniqueKeyUpdateMode) {
+	if !p.IsSetUniqueKeyUpdateMode() {
+		return TOlapTableSchemaParam_UniqueKeyUpdateMode_DEFAULT
+	}
+	return *p.UniqueKeyUpdateMode
+}
+
+var TOlapTableSchemaParam_SequenceMapColUniqueId_DEFAULT int32 = -1
+
+func (p *TOlapTableSchemaParam) GetSequenceMapColUniqueId() (v int32) {
+	if !p.IsSetSequenceMapColUniqueId() {
+		return TOlapTableSchemaParam_SequenceMapColUniqueId_DEFAULT
+	}
+	return p.SequenceMapColUniqueId
+}
 func (p *TOlapTableSchemaParam) SetDbId(val int64) {
 	p.DbId = val
 }
@@ -7599,6 +7717,12 @@ func (p *TOlapTableSchemaParam) SetAutoIncrementColumnUniqueId(val int32) {
 func (p *TOlapTableSchemaParam) SetInvertedIndexFileStorageFormat(val types.TInvertedIndexFileStorageFormat) {
 	p.InvertedIndexFileStorageFormat = val
 }
+func (p *TOlapTableSchemaParam) SetUniqueKeyUpdateMode(val *types.TUniqueKeyUpdateMode) {
+	p.UniqueKeyUpdateMode = val
+}
+func (p *TOlapTableSchemaParam) SetSequenceMapColUniqueId(val int32) {
+	p.SequenceMapColUniqueId = val
+}
 
 var fieldIDToName_TOlapTableSchemaParam = map[int16]string{
 	1:  "db_id",
@@ -7614,6 +7738,8 @@ var fieldIDToName_TOlapTableSchemaParam = map[int16]string{
 	11: "auto_increment_column",
 	12: "auto_increment_column_unique_id",
 	13: "inverted_index_file_storage_format",
+	14: "unique_key_update_mode",
+	15: "sequence_map_col_unique_id",
 }
 
 func (p *TOlapTableSchemaParam) IsSetTupleDesc() bool {
@@ -7646,6 +7772,14 @@ func (p *TOlapTableSchemaParam) IsSetAutoIncrementColumnUniqueId() bool {
 
 func (p *TOlapTableSchemaParam) IsSetInvertedIndexFileStorageFormat() bool {
 	return p.InvertedIndexFileStorageFormat != TOlapTableSchemaParam_InvertedIndexFileStorageFormat_DEFAULT
+}
+
+func (p *TOlapTableSchemaParam) IsSetUniqueKeyUpdateMode() bool {
+	return p.UniqueKeyUpdateMode != nil
+}
+
+func (p *TOlapTableSchemaParam) IsSetSequenceMapColUniqueId() bool {
+	return p.SequenceMapColUniqueId != TOlapTableSchemaParam_SequenceMapColUniqueId_DEFAULT
 }
 
 func (p *TOlapTableSchemaParam) Read(iprot thrift.TProtocol) (err error) {
@@ -7778,6 +7912,22 @@ func (p *TOlapTableSchemaParam) Read(iprot thrift.TProtocol) (err error) {
 		case 13:
 			if fieldTypeId == thrift.I32 {
 				if err = p.ReadField13(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 14:
+			if fieldTypeId == thrift.I32 {
+				if err = p.ReadField14(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 15:
+			if fieldTypeId == thrift.I32 {
+				if err = p.ReadField15(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -8019,6 +8169,29 @@ func (p *TOlapTableSchemaParam) ReadField13(iprot thrift.TProtocol) error {
 	p.InvertedIndexFileStorageFormat = _field
 	return nil
 }
+func (p *TOlapTableSchemaParam) ReadField14(iprot thrift.TProtocol) error {
+
+	var _field *types.TUniqueKeyUpdateMode
+	if v, err := iprot.ReadI32(); err != nil {
+		return err
+	} else {
+		tmp := types.TUniqueKeyUpdateMode(v)
+		_field = &tmp
+	}
+	p.UniqueKeyUpdateMode = _field
+	return nil
+}
+func (p *TOlapTableSchemaParam) ReadField15(iprot thrift.TProtocol) error {
+
+	var _field int32
+	if v, err := iprot.ReadI32(); err != nil {
+		return err
+	} else {
+		_field = v
+	}
+	p.SequenceMapColUniqueId = _field
+	return nil
+}
 
 func (p *TOlapTableSchemaParam) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -8076,6 +8249,14 @@ func (p *TOlapTableSchemaParam) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField13(oprot); err != nil {
 			fieldId = 13
+			goto WriteFieldError
+		}
+		if err = p.writeField14(oprot); err != nil {
+			fieldId = 14
+			goto WriteFieldError
+		}
+		if err = p.writeField15(oprot); err != nil {
+			fieldId = 15
 			goto WriteFieldError
 		}
 	}
@@ -8355,6 +8536,44 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 13 end error: ", p), err)
 }
 
+func (p *TOlapTableSchemaParam) writeField14(oprot thrift.TProtocol) (err error) {
+	if p.IsSetUniqueKeyUpdateMode() {
+		if err = oprot.WriteFieldBegin("unique_key_update_mode", thrift.I32, 14); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI32(int32(*p.UniqueKeyUpdateMode)); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 14 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 14 end error: ", p), err)
+}
+
+func (p *TOlapTableSchemaParam) writeField15(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSequenceMapColUniqueId() {
+		if err = oprot.WriteFieldBegin("sequence_map_col_unique_id", thrift.I32, 15); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI32(p.SequenceMapColUniqueId); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 15 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 15 end error: ", p), err)
+}
+
 func (p *TOlapTableSchemaParam) String() string {
 	if p == nil {
 		return "<nil>"
@@ -8406,6 +8625,12 @@ func (p *TOlapTableSchemaParam) DeepEqual(ano *TOlapTableSchemaParam) bool {
 		return false
 	}
 	if !p.Field13DeepEqual(ano.InvertedIndexFileStorageFormat) {
+		return false
+	}
+	if !p.Field14DeepEqual(ano.UniqueKeyUpdateMode) {
+		return false
+	}
+	if !p.Field15DeepEqual(ano.SequenceMapColUniqueId) {
 		return false
 	}
 	return true
@@ -8531,6 +8756,25 @@ func (p *TOlapTableSchemaParam) Field12DeepEqual(src int32) bool {
 func (p *TOlapTableSchemaParam) Field13DeepEqual(src types.TInvertedIndexFileStorageFormat) bool {
 
 	if p.InvertedIndexFileStorageFormat != src {
+		return false
+	}
+	return true
+}
+func (p *TOlapTableSchemaParam) Field14DeepEqual(src *types.TUniqueKeyUpdateMode) bool {
+
+	if p.UniqueKeyUpdateMode == src {
+		return true
+	} else if p.UniqueKeyUpdateMode == nil || src == nil {
+		return false
+	}
+	if *p.UniqueKeyUpdateMode != *src {
+		return false
+	}
+	return true
+}
+func (p *TOlapTableSchemaParam) Field15DeepEqual(src int32) bool {
+
+	if p.SequenceMapColUniqueId != src {
 		return false
 	}
 	return true

--- a/pkg/rpc/kitex_gen/descriptors/k-Descriptors.go
+++ b/pkg/rpc/kitex_gen/descriptors/k-Descriptors.go
@@ -4510,6 +4510,20 @@ func (p *TOlapTableIndex) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 7:
+			if fieldTypeId == thrift.LIST {
+				l, err = p.FastReadField7(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -4669,6 +4683,36 @@ func (p *TOlapTableIndex) FastReadField6(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TOlapTableIndex) FastReadField7(buf []byte) (int, error) {
+	offset := 0
+
+	_, size, l, err := bthrift.Binary.ReadListBegin(buf[offset:])
+	offset += l
+	if err != nil {
+		return offset, err
+	}
+	p.ColumnUniqueIds = make([]int32, 0, size)
+	for i := 0; i < size; i++ {
+		var _elem int32
+		if v, l, err := bthrift.Binary.ReadI32(buf[offset:]); err != nil {
+			return offset, err
+		} else {
+			offset += l
+
+			_elem = v
+
+		}
+
+		p.ColumnUniqueIds = append(p.ColumnUniqueIds, _elem)
+	}
+	if l, err := bthrift.Binary.ReadListEnd(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TOlapTableIndex) FastWrite(buf []byte) int {
 	return 0
@@ -4684,6 +4728,7 @@ func (p *TOlapTableIndex) FastWriteNocopy(buf []byte, binaryWriter bthrift.Binar
 		offset += p.fastWriteField3(buf[offset:], binaryWriter)
 		offset += p.fastWriteField4(buf[offset:], binaryWriter)
 		offset += p.fastWriteField6(buf[offset:], binaryWriter)
+		offset += p.fastWriteField7(buf[offset:], binaryWriter)
 	}
 	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
 	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
@@ -4700,6 +4745,7 @@ func (p *TOlapTableIndex) BLength() int {
 		l += p.field4Length()
 		l += p.field5Length()
 		l += p.field6Length()
+		l += p.field7Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -4791,6 +4837,25 @@ func (p *TOlapTableIndex) fastWriteField6(buf []byte, binaryWriter bthrift.Binar
 	return offset
 }
 
+func (p *TOlapTableIndex) fastWriteField7(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetColumnUniqueIds() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "column_unique_ids", thrift.LIST, 7)
+		listBeginOffset := offset
+		offset += bthrift.Binary.ListBeginLength(thrift.I32, 0)
+		var length int
+		for _, v := range p.ColumnUniqueIds {
+			length++
+			offset += bthrift.Binary.WriteI32(buf[offset:], v)
+
+		}
+		bthrift.Binary.WriteListBegin(buf[listBeginOffset:], thrift.I32, length)
+		offset += bthrift.Binary.WriteListEnd(buf[offset:])
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TOlapTableIndex) field1Length() int {
 	l := 0
 	if p.IsSetIndexName() {
@@ -4863,6 +4928,19 @@ func (p *TOlapTableIndex) field6Length() int {
 
 		}
 		l += bthrift.Binary.MapEndLength()
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TOlapTableIndex) field7Length() int {
+	l := 0
+	if p.IsSetColumnUniqueIds() {
+		l += bthrift.Binary.FieldBeginLength("column_unique_ids", thrift.LIST, 7)
+		l += bthrift.Binary.ListBeginLength(thrift.I32, len(p.ColumnUniqueIds))
+		var tmpV int32
+		l += bthrift.Binary.I32Length(int32(tmpV)) * len(p.ColumnUniqueIds)
+		l += bthrift.Binary.ListEndLength()
 		l += bthrift.Binary.FieldEndLength()
 	}
 	return l
@@ -5559,6 +5637,34 @@ func (p *TOlapTableSchemaParam) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 14:
+			if fieldTypeId == thrift.I32 {
+				l, err = p.FastReadField14(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 15:
+			if fieldTypeId == thrift.I32 {
+				l, err = p.FastReadField15(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -5845,6 +5951,35 @@ func (p *TOlapTableSchemaParam) FastReadField13(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TOlapTableSchemaParam) FastReadField14(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI32(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+
+		tmp := types.TUniqueKeyUpdateMode(v)
+		p.UniqueKeyUpdateMode = &tmp
+
+	}
+	return offset, nil
+}
+
+func (p *TOlapTableSchemaParam) FastReadField15(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI32(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+
+		p.SequenceMapColUniqueId = v
+
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TOlapTableSchemaParam) FastWrite(buf []byte) int {
 	return 0
@@ -5861,12 +5996,14 @@ func (p *TOlapTableSchemaParam) FastWriteNocopy(buf []byte, binaryWriter bthrift
 		offset += p.fastWriteField8(buf[offset:], binaryWriter)
 		offset += p.fastWriteField10(buf[offset:], binaryWriter)
 		offset += p.fastWriteField12(buf[offset:], binaryWriter)
+		offset += p.fastWriteField15(buf[offset:], binaryWriter)
 		offset += p.fastWriteField4(buf[offset:], binaryWriter)
 		offset += p.fastWriteField5(buf[offset:], binaryWriter)
 		offset += p.fastWriteField6(buf[offset:], binaryWriter)
 		offset += p.fastWriteField9(buf[offset:], binaryWriter)
 		offset += p.fastWriteField11(buf[offset:], binaryWriter)
 		offset += p.fastWriteField13(buf[offset:], binaryWriter)
+		offset += p.fastWriteField14(buf[offset:], binaryWriter)
 	}
 	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
 	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
@@ -5890,6 +6027,8 @@ func (p *TOlapTableSchemaParam) BLength() int {
 		l += p.field11Length()
 		l += p.field12Length()
 		l += p.field13Length()
+		l += p.field14Length()
+		l += p.field15Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -6048,6 +6187,28 @@ func (p *TOlapTableSchemaParam) fastWriteField13(buf []byte, binaryWriter bthrif
 	return offset
 }
 
+func (p *TOlapTableSchemaParam) fastWriteField14(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetUniqueKeyUpdateMode() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "unique_key_update_mode", thrift.I32, 14)
+		offset += bthrift.Binary.WriteI32(buf[offset:], int32(*p.UniqueKeyUpdateMode))
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TOlapTableSchemaParam) fastWriteField15(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetSequenceMapColUniqueId() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "sequence_map_col_unique_id", thrift.I32, 15)
+		offset += bthrift.Binary.WriteI32(buf[offset:], p.SequenceMapColUniqueId)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TOlapTableSchemaParam) field1Length() int {
 	l := 0
 	l += bthrift.Binary.FieldBeginLength("db_id", thrift.I64, 1)
@@ -6182,6 +6343,28 @@ func (p *TOlapTableSchemaParam) field13Length() int {
 	if p.IsSetInvertedIndexFileStorageFormat() {
 		l += bthrift.Binary.FieldBeginLength("inverted_index_file_storage_format", thrift.I32, 13)
 		l += bthrift.Binary.I32Length(int32(p.InvertedIndexFileStorageFormat))
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TOlapTableSchemaParam) field14Length() int {
+	l := 0
+	if p.IsSetUniqueKeyUpdateMode() {
+		l += bthrift.Binary.FieldBeginLength("unique_key_update_mode", thrift.I32, 14)
+		l += bthrift.Binary.I32Length(int32(*p.UniqueKeyUpdateMode))
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TOlapTableSchemaParam) field15Length() int {
+	l := 0
+	if p.IsSetSequenceMapColUniqueId() {
+		l += bthrift.Binary.FieldBeginLength("sequence_map_col_unique_id", thrift.I32, 15)
+		l += bthrift.Binary.I32Length(p.SequenceMapColUniqueId)
 
 		l += bthrift.Binary.FieldEndLength()
 	}

--- a/pkg/rpc/kitex_gen/frontendservice/FrontendService.go
+++ b/pkg/rpc/kitex_gen/frontendservice/FrontendService.go
@@ -15610,6 +15610,8 @@ func (p *TQueryProfile) Field5DeepEqual(src []*runtimeprofile.TRuntimeProfileTre
 type TFragmentInstanceReport struct {
 	FragmentInstanceId *types.TUniqueId `thrift:"fragment_instance_id,1,optional" frugal:"1,optional,types.TUniqueId" json:"fragment_instance_id,omitempty"`
 	NumFinishedRange   *int32           `thrift:"num_finished_range,2,optional" frugal:"2,optional,i32" json:"num_finished_range,omitempty"`
+	LoadedRows         *int64           `thrift:"loaded_rows,3,optional" frugal:"3,optional,i64" json:"loaded_rows,omitempty"`
+	LoadedBytes        *int64           `thrift:"loaded_bytes,4,optional" frugal:"4,optional,i64" json:"loaded_bytes,omitempty"`
 }
 
 func NewTFragmentInstanceReport() *TFragmentInstanceReport {
@@ -15636,16 +15638,42 @@ func (p *TFragmentInstanceReport) GetNumFinishedRange() (v int32) {
 	}
 	return *p.NumFinishedRange
 }
+
+var TFragmentInstanceReport_LoadedRows_DEFAULT int64
+
+func (p *TFragmentInstanceReport) GetLoadedRows() (v int64) {
+	if !p.IsSetLoadedRows() {
+		return TFragmentInstanceReport_LoadedRows_DEFAULT
+	}
+	return *p.LoadedRows
+}
+
+var TFragmentInstanceReport_LoadedBytes_DEFAULT int64
+
+func (p *TFragmentInstanceReport) GetLoadedBytes() (v int64) {
+	if !p.IsSetLoadedBytes() {
+		return TFragmentInstanceReport_LoadedBytes_DEFAULT
+	}
+	return *p.LoadedBytes
+}
 func (p *TFragmentInstanceReport) SetFragmentInstanceId(val *types.TUniqueId) {
 	p.FragmentInstanceId = val
 }
 func (p *TFragmentInstanceReport) SetNumFinishedRange(val *int32) {
 	p.NumFinishedRange = val
 }
+func (p *TFragmentInstanceReport) SetLoadedRows(val *int64) {
+	p.LoadedRows = val
+}
+func (p *TFragmentInstanceReport) SetLoadedBytes(val *int64) {
+	p.LoadedBytes = val
+}
 
 var fieldIDToName_TFragmentInstanceReport = map[int16]string{
 	1: "fragment_instance_id",
 	2: "num_finished_range",
+	3: "loaded_rows",
+	4: "loaded_bytes",
 }
 
 func (p *TFragmentInstanceReport) IsSetFragmentInstanceId() bool {
@@ -15654,6 +15682,14 @@ func (p *TFragmentInstanceReport) IsSetFragmentInstanceId() bool {
 
 func (p *TFragmentInstanceReport) IsSetNumFinishedRange() bool {
 	return p.NumFinishedRange != nil
+}
+
+func (p *TFragmentInstanceReport) IsSetLoadedRows() bool {
+	return p.LoadedRows != nil
+}
+
+func (p *TFragmentInstanceReport) IsSetLoadedBytes() bool {
+	return p.LoadedBytes != nil
 }
 
 func (p *TFragmentInstanceReport) Read(iprot thrift.TProtocol) (err error) {
@@ -15686,6 +15722,22 @@ func (p *TFragmentInstanceReport) Read(iprot thrift.TProtocol) (err error) {
 		case 2:
 			if fieldTypeId == thrift.I32 {
 				if err = p.ReadField2(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 3:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField3(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 4:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField4(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -15739,6 +15791,28 @@ func (p *TFragmentInstanceReport) ReadField2(iprot thrift.TProtocol) error {
 	p.NumFinishedRange = _field
 	return nil
 }
+func (p *TFragmentInstanceReport) ReadField3(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.LoadedRows = _field
+	return nil
+}
+func (p *TFragmentInstanceReport) ReadField4(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.LoadedBytes = _field
+	return nil
+}
 
 func (p *TFragmentInstanceReport) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -15752,6 +15826,14 @@ func (p *TFragmentInstanceReport) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField2(oprot); err != nil {
 			fieldId = 2
+			goto WriteFieldError
+		}
+		if err = p.writeField3(oprot); err != nil {
+			fieldId = 3
+			goto WriteFieldError
+		}
+		if err = p.writeField4(oprot); err != nil {
+			fieldId = 4
 			goto WriteFieldError
 		}
 	}
@@ -15810,6 +15892,44 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 2 end error: ", p), err)
 }
 
+func (p *TFragmentInstanceReport) writeField3(oprot thrift.TProtocol) (err error) {
+	if p.IsSetLoadedRows() {
+		if err = oprot.WriteFieldBegin("loaded_rows", thrift.I64, 3); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.LoadedRows); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 end error: ", p), err)
+}
+
+func (p *TFragmentInstanceReport) writeField4(oprot thrift.TProtocol) (err error) {
+	if p.IsSetLoadedBytes() {
+		if err = oprot.WriteFieldBegin("loaded_bytes", thrift.I64, 4); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.LoadedBytes); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 4 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 4 end error: ", p), err)
+}
+
 func (p *TFragmentInstanceReport) String() string {
 	if p == nil {
 		return "<nil>"
@@ -15830,6 +15950,12 @@ func (p *TFragmentInstanceReport) DeepEqual(ano *TFragmentInstanceReport) bool {
 	if !p.Field2DeepEqual(ano.NumFinishedRange) {
 		return false
 	}
+	if !p.Field3DeepEqual(ano.LoadedRows) {
+		return false
+	}
+	if !p.Field4DeepEqual(ano.LoadedBytes) {
+		return false
+	}
 	return true
 }
 
@@ -15848,6 +15974,30 @@ func (p *TFragmentInstanceReport) Field2DeepEqual(src *int32) bool {
 		return false
 	}
 	if *p.NumFinishedRange != *src {
+		return false
+	}
+	return true
+}
+func (p *TFragmentInstanceReport) Field3DeepEqual(src *int64) bool {
+
+	if p.LoadedRows == src {
+		return true
+	} else if p.LoadedRows == nil || src == nil {
+		return false
+	}
+	if *p.LoadedRows != *src {
+		return false
+	}
+	return true
+}
+func (p *TFragmentInstanceReport) Field4DeepEqual(src *int64) bool {
+
+	if p.LoadedBytes == src {
+		return true
+	} else if p.LoadedBytes == nil || src == nil {
+		return false
+	}
+	if *p.LoadedBytes != *src {
 		return false
 	}
 	return true
@@ -28144,6 +28294,7 @@ type TStreamLoadPutRequest struct {
 	GroupCommit          *bool                        `thrift:"group_commit,54,optional" frugal:"54,optional,bool" json:"group_commit,omitempty"`
 	StreamPerNode        *int32                       `thrift:"stream_per_node,55,optional" frugal:"55,optional,i32" json:"stream_per_node,omitempty"`
 	GroupCommitMode      *string                      `thrift:"group_commit_mode,56,optional" frugal:"56,optional,string" json:"group_commit_mode,omitempty"`
+	UniqueKeyUpdateMode  *types.TUniqueKeyUpdateMode  `thrift:"unique_key_update_mode,57,optional" frugal:"57,optional,TUniqueKeyUpdateMode" json:"unique_key_update_mode,omitempty"`
 	CloudCluster         *string                      `thrift:"cloud_cluster,1000,optional" frugal:"1000,optional,string" json:"cloud_cluster,omitempty"`
 	TableId              *int64                       `thrift:"table_id,1001,optional" frugal:"1001,optional,i64" json:"table_id,omitempty"`
 }
@@ -28624,6 +28775,15 @@ func (p *TStreamLoadPutRequest) GetGroupCommitMode() (v string) {
 	return *p.GroupCommitMode
 }
 
+var TStreamLoadPutRequest_UniqueKeyUpdateMode_DEFAULT types.TUniqueKeyUpdateMode
+
+func (p *TStreamLoadPutRequest) GetUniqueKeyUpdateMode() (v types.TUniqueKeyUpdateMode) {
+	if !p.IsSetUniqueKeyUpdateMode() {
+		return TStreamLoadPutRequest_UniqueKeyUpdateMode_DEFAULT
+	}
+	return *p.UniqueKeyUpdateMode
+}
+
 var TStreamLoadPutRequest_CloudCluster_DEFAULT string
 
 func (p *TStreamLoadPutRequest) GetCloudCluster() (v string) {
@@ -28809,6 +28969,9 @@ func (p *TStreamLoadPutRequest) SetStreamPerNode(val *int32) {
 func (p *TStreamLoadPutRequest) SetGroupCommitMode(val *string) {
 	p.GroupCommitMode = val
 }
+func (p *TStreamLoadPutRequest) SetUniqueKeyUpdateMode(val *types.TUniqueKeyUpdateMode) {
+	p.UniqueKeyUpdateMode = val
+}
 func (p *TStreamLoadPutRequest) SetCloudCluster(val *string) {
 	p.CloudCluster = val
 }
@@ -28873,6 +29036,7 @@ var fieldIDToName_TStreamLoadPutRequest = map[int16]string{
 	54:   "group_commit",
 	55:   "stream_per_node",
 	56:   "group_commit_mode",
+	57:   "unique_key_update_mode",
 	1000: "cloud_cluster",
 	1001: "table_id",
 }
@@ -29071,6 +29235,10 @@ func (p *TStreamLoadPutRequest) IsSetStreamPerNode() bool {
 
 func (p *TStreamLoadPutRequest) IsSetGroupCommitMode() bool {
 	return p.GroupCommitMode != nil
+}
+
+func (p *TStreamLoadPutRequest) IsSetUniqueKeyUpdateMode() bool {
+	return p.UniqueKeyUpdateMode != nil
 }
 
 func (p *TStreamLoadPutRequest) IsSetCloudCluster() bool {
@@ -29559,6 +29727,14 @@ func (p *TStreamLoadPutRequest) Read(iprot thrift.TProtocol) (err error) {
 		case 56:
 			if fieldTypeId == thrift.STRING {
 				if err = p.ReadField56(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 57:
+			if fieldTypeId == thrift.I32 {
+				if err = p.ReadField57(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -30277,6 +30453,18 @@ func (p *TStreamLoadPutRequest) ReadField56(iprot thrift.TProtocol) error {
 	p.GroupCommitMode = _field
 	return nil
 }
+func (p *TStreamLoadPutRequest) ReadField57(iprot thrift.TProtocol) error {
+
+	var _field *types.TUniqueKeyUpdateMode
+	if v, err := iprot.ReadI32(); err != nil {
+		return err
+	} else {
+		tmp := types.TUniqueKeyUpdateMode(v)
+		_field = &tmp
+	}
+	p.UniqueKeyUpdateMode = _field
+	return nil
+}
 func (p *TStreamLoadPutRequest) ReadField1000(iprot thrift.TProtocol) error {
 
 	var _field *string
@@ -30528,6 +30716,10 @@ func (p *TStreamLoadPutRequest) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField56(oprot); err != nil {
 			fieldId = 56
+			goto WriteFieldError
+		}
+		if err = p.writeField57(oprot); err != nil {
+			fieldId = 57
 			goto WriteFieldError
 		}
 		if err = p.writeField1000(oprot); err != nil {
@@ -31612,6 +31804,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 56 end error: ", p), err)
 }
 
+func (p *TStreamLoadPutRequest) writeField57(oprot thrift.TProtocol) (err error) {
+	if p.IsSetUniqueKeyUpdateMode() {
+		if err = oprot.WriteFieldBegin("unique_key_update_mode", thrift.I32, 57); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI32(int32(*p.UniqueKeyUpdateMode)); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 57 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 57 end error: ", p), err)
+}
+
 func (p *TStreamLoadPutRequest) writeField1000(oprot thrift.TProtocol) (err error) {
 	if p.IsSetCloudCluster() {
 		if err = oprot.WriteFieldBegin("cloud_cluster", thrift.STRING, 1000); err != nil {
@@ -31830,6 +32041,9 @@ func (p *TStreamLoadPutRequest) DeepEqual(ano *TStreamLoadPutRequest) bool {
 		return false
 	}
 	if !p.Field56DeepEqual(ano.GroupCommitMode) {
+		return false
+	}
+	if !p.Field57DeepEqual(ano.UniqueKeyUpdateMode) {
 		return false
 	}
 	if !p.Field1000DeepEqual(ano.CloudCluster) {
@@ -32470,6 +32684,18 @@ func (p *TStreamLoadPutRequest) Field56DeepEqual(src *string) bool {
 		return false
 	}
 	if strings.Compare(*p.GroupCommitMode, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TStreamLoadPutRequest) Field57DeepEqual(src *types.TUniqueKeyUpdateMode) bool {
+
+	if p.UniqueKeyUpdateMode == src {
+		return true
+	} else if p.UniqueKeyUpdateMode == nil || src == nil {
+		return false
+	}
+	if *p.UniqueKeyUpdateMode != *src {
 		return false
 	}
 	return true
@@ -46125,6 +46351,7 @@ type TMetadataTableRequestParams struct {
 	TasksMetadataParams             *plannodes.TTasksMetadataParams             `thrift:"tasks_metadata_params,10,optional" frugal:"10,optional,plannodes.TTasksMetadataParams" json:"tasks_metadata_params,omitempty"`
 	PartitionsMetadataParams        *plannodes.TPartitionsMetadataParams        `thrift:"partitions_metadata_params,11,optional" frugal:"11,optional,plannodes.TPartitionsMetadataParams" json:"partitions_metadata_params,omitempty"`
 	MetaCacheStatsParams            *plannodes.TMetaCacheStatsParams            `thrift:"meta_cache_stats_params,12,optional" frugal:"12,optional,plannodes.TMetaCacheStatsParams" json:"meta_cache_stats_params,omitempty"`
+	PartitionValuesMetadataParams   *plannodes.TPartitionValuesMetadataParams   `thrift:"partition_values_metadata_params,13,optional" frugal:"13,optional,plannodes.TPartitionValuesMetadataParams" json:"partition_values_metadata_params,omitempty"`
 }
 
 func NewTMetadataTableRequestParams() *TMetadataTableRequestParams {
@@ -46241,6 +46468,15 @@ func (p *TMetadataTableRequestParams) GetMetaCacheStatsParams() (v *plannodes.TM
 	}
 	return p.MetaCacheStatsParams
 }
+
+var TMetadataTableRequestParams_PartitionValuesMetadataParams_DEFAULT *plannodes.TPartitionValuesMetadataParams
+
+func (p *TMetadataTableRequestParams) GetPartitionValuesMetadataParams() (v *plannodes.TPartitionValuesMetadataParams) {
+	if !p.IsSetPartitionValuesMetadataParams() {
+		return TMetadataTableRequestParams_PartitionValuesMetadataParams_DEFAULT
+	}
+	return p.PartitionValuesMetadataParams
+}
 func (p *TMetadataTableRequestParams) SetMetadataType(val *types.TMetadataType) {
 	p.MetadataType = val
 }
@@ -46277,6 +46513,9 @@ func (p *TMetadataTableRequestParams) SetPartitionsMetadataParams(val *plannodes
 func (p *TMetadataTableRequestParams) SetMetaCacheStatsParams(val *plannodes.TMetaCacheStatsParams) {
 	p.MetaCacheStatsParams = val
 }
+func (p *TMetadataTableRequestParams) SetPartitionValuesMetadataParams(val *plannodes.TPartitionValuesMetadataParams) {
+	p.PartitionValuesMetadataParams = val
+}
 
 var fieldIDToName_TMetadataTableRequestParams = map[int16]string{
 	1:  "metadata_type",
@@ -46291,6 +46530,7 @@ var fieldIDToName_TMetadataTableRequestParams = map[int16]string{
 	10: "tasks_metadata_params",
 	11: "partitions_metadata_params",
 	12: "meta_cache_stats_params",
+	13: "partition_values_metadata_params",
 }
 
 func (p *TMetadataTableRequestParams) IsSetMetadataType() bool {
@@ -46339,6 +46579,10 @@ func (p *TMetadataTableRequestParams) IsSetPartitionsMetadataParams() bool {
 
 func (p *TMetadataTableRequestParams) IsSetMetaCacheStatsParams() bool {
 	return p.MetaCacheStatsParams != nil
+}
+
+func (p *TMetadataTableRequestParams) IsSetPartitionValuesMetadataParams() bool {
+	return p.PartitionValuesMetadataParams != nil
 }
 
 func (p *TMetadataTableRequestParams) Read(iprot thrift.TProtocol) (err error) {
@@ -46451,6 +46695,14 @@ func (p *TMetadataTableRequestParams) Read(iprot thrift.TProtocol) (err error) {
 		case 12:
 			if fieldTypeId == thrift.STRUCT {
 				if err = p.ReadField12(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 13:
+			if fieldTypeId == thrift.STRUCT {
+				if err = p.ReadField13(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -46600,6 +46852,14 @@ func (p *TMetadataTableRequestParams) ReadField12(iprot thrift.TProtocol) error 
 	p.MetaCacheStatsParams = _field
 	return nil
 }
+func (p *TMetadataTableRequestParams) ReadField13(iprot thrift.TProtocol) error {
+	_field := plannodes.NewTPartitionValuesMetadataParams()
+	if err := _field.Read(iprot); err != nil {
+		return err
+	}
+	p.PartitionValuesMetadataParams = _field
+	return nil
+}
 
 func (p *TMetadataTableRequestParams) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -46653,6 +46913,10 @@ func (p *TMetadataTableRequestParams) Write(oprot thrift.TProtocol) (err error) 
 		}
 		if err = p.writeField12(oprot); err != nil {
 			fieldId = 12
+			goto WriteFieldError
+		}
+		if err = p.writeField13(oprot); err != nil {
+			fieldId = 13
 			goto WriteFieldError
 		}
 	}
@@ -46909,6 +47173,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 12 end error: ", p), err)
 }
 
+func (p *TMetadataTableRequestParams) writeField13(oprot thrift.TProtocol) (err error) {
+	if p.IsSetPartitionValuesMetadataParams() {
+		if err = oprot.WriteFieldBegin("partition_values_metadata_params", thrift.STRUCT, 13); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := p.PartitionValuesMetadataParams.Write(oprot); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 13 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 13 end error: ", p), err)
+}
+
 func (p *TMetadataTableRequestParams) String() string {
 	if p == nil {
 		return "<nil>"
@@ -46957,6 +47240,9 @@ func (p *TMetadataTableRequestParams) DeepEqual(ano *TMetadataTableRequestParams
 		return false
 	}
 	if !p.Field12DeepEqual(ano.MetaCacheStatsParams) {
+		return false
+	}
+	if !p.Field13DeepEqual(ano.PartitionValuesMetadataParams) {
 		return false
 	}
 	return true
@@ -47053,6 +47339,13 @@ func (p *TMetadataTableRequestParams) Field11DeepEqual(src *plannodes.TPartition
 func (p *TMetadataTableRequestParams) Field12DeepEqual(src *plannodes.TMetaCacheStatsParams) bool {
 
 	if !p.MetaCacheStatsParams.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+func (p *TMetadataTableRequestParams) Field13DeepEqual(src *plannodes.TPartitionValuesMetadataParams) bool {
+
+	if !p.PartitionValuesMetadataParams.DeepEqual(src) {
 		return false
 	}
 	return true
@@ -55007,15 +55300,16 @@ func (p *TGetTabletReplicaInfosResult_) Field3DeepEqual(src *string) bool {
 }
 
 type TGetSnapshotRequest struct {
-	Cluster      *string        `thrift:"cluster,1,optional" frugal:"1,optional,string" json:"cluster,omitempty"`
-	User         *string        `thrift:"user,2,optional" frugal:"2,optional,string" json:"user,omitempty"`
-	Passwd       *string        `thrift:"passwd,3,optional" frugal:"3,optional,string" json:"passwd,omitempty"`
-	Db           *string        `thrift:"db,4,optional" frugal:"4,optional,string" json:"db,omitempty"`
-	Table        *string        `thrift:"table,5,optional" frugal:"5,optional,string" json:"table,omitempty"`
-	Token        *string        `thrift:"token,6,optional" frugal:"6,optional,string" json:"token,omitempty"`
-	LabelName    *string        `thrift:"label_name,7,optional" frugal:"7,optional,string" json:"label_name,omitempty"`
-	SnapshotName *string        `thrift:"snapshot_name,8,optional" frugal:"8,optional,string" json:"snapshot_name,omitempty"`
-	SnapshotType *TSnapshotType `thrift:"snapshot_type,9,optional" frugal:"9,optional,TSnapshotType" json:"snapshot_type,omitempty"`
+	Cluster        *string        `thrift:"cluster,1,optional" frugal:"1,optional,string" json:"cluster,omitempty"`
+	User           *string        `thrift:"user,2,optional" frugal:"2,optional,string" json:"user,omitempty"`
+	Passwd         *string        `thrift:"passwd,3,optional" frugal:"3,optional,string" json:"passwd,omitempty"`
+	Db             *string        `thrift:"db,4,optional" frugal:"4,optional,string" json:"db,omitempty"`
+	Table          *string        `thrift:"table,5,optional" frugal:"5,optional,string" json:"table,omitempty"`
+	Token          *string        `thrift:"token,6,optional" frugal:"6,optional,string" json:"token,omitempty"`
+	LabelName      *string        `thrift:"label_name,7,optional" frugal:"7,optional,string" json:"label_name,omitempty"`
+	SnapshotName   *string        `thrift:"snapshot_name,8,optional" frugal:"8,optional,string" json:"snapshot_name,omitempty"`
+	SnapshotType   *TSnapshotType `thrift:"snapshot_type,9,optional" frugal:"9,optional,TSnapshotType" json:"snapshot_type,omitempty"`
+	EnableCompress *bool          `thrift:"enable_compress,10,optional" frugal:"10,optional,bool" json:"enable_compress,omitempty"`
 }
 
 func NewTGetSnapshotRequest() *TGetSnapshotRequest {
@@ -55105,6 +55399,15 @@ func (p *TGetSnapshotRequest) GetSnapshotType() (v TSnapshotType) {
 	}
 	return *p.SnapshotType
 }
+
+var TGetSnapshotRequest_EnableCompress_DEFAULT bool
+
+func (p *TGetSnapshotRequest) GetEnableCompress() (v bool) {
+	if !p.IsSetEnableCompress() {
+		return TGetSnapshotRequest_EnableCompress_DEFAULT
+	}
+	return *p.EnableCompress
+}
 func (p *TGetSnapshotRequest) SetCluster(val *string) {
 	p.Cluster = val
 }
@@ -55132,17 +55435,21 @@ func (p *TGetSnapshotRequest) SetSnapshotName(val *string) {
 func (p *TGetSnapshotRequest) SetSnapshotType(val *TSnapshotType) {
 	p.SnapshotType = val
 }
+func (p *TGetSnapshotRequest) SetEnableCompress(val *bool) {
+	p.EnableCompress = val
+}
 
 var fieldIDToName_TGetSnapshotRequest = map[int16]string{
-	1: "cluster",
-	2: "user",
-	3: "passwd",
-	4: "db",
-	5: "table",
-	6: "token",
-	7: "label_name",
-	8: "snapshot_name",
-	9: "snapshot_type",
+	1:  "cluster",
+	2:  "user",
+	3:  "passwd",
+	4:  "db",
+	5:  "table",
+	6:  "token",
+	7:  "label_name",
+	8:  "snapshot_name",
+	9:  "snapshot_type",
+	10: "enable_compress",
 }
 
 func (p *TGetSnapshotRequest) IsSetCluster() bool {
@@ -55179,6 +55486,10 @@ func (p *TGetSnapshotRequest) IsSetSnapshotName() bool {
 
 func (p *TGetSnapshotRequest) IsSetSnapshotType() bool {
 	return p.SnapshotType != nil
+}
+
+func (p *TGetSnapshotRequest) IsSetEnableCompress() bool {
+	return p.EnableCompress != nil
 }
 
 func (p *TGetSnapshotRequest) Read(iprot thrift.TProtocol) (err error) {
@@ -55267,6 +55578,14 @@ func (p *TGetSnapshotRequest) Read(iprot thrift.TProtocol) (err error) {
 		case 9:
 			if fieldTypeId == thrift.I32 {
 				if err = p.ReadField9(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 10:
+			if fieldTypeId == thrift.BOOL {
+				if err = p.ReadField10(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -55401,6 +55720,17 @@ func (p *TGetSnapshotRequest) ReadField9(iprot thrift.TProtocol) error {
 	p.SnapshotType = _field
 	return nil
 }
+func (p *TGetSnapshotRequest) ReadField10(iprot thrift.TProtocol) error {
+
+	var _field *bool
+	if v, err := iprot.ReadBool(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.EnableCompress = _field
+	return nil
+}
 
 func (p *TGetSnapshotRequest) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -55442,6 +55772,10 @@ func (p *TGetSnapshotRequest) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField9(oprot); err != nil {
 			fieldId = 9
+			goto WriteFieldError
+		}
+		if err = p.writeField10(oprot); err != nil {
+			fieldId = 10
 			goto WriteFieldError
 		}
 	}
@@ -55633,6 +55967,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 9 end error: ", p), err)
 }
 
+func (p *TGetSnapshotRequest) writeField10(oprot thrift.TProtocol) (err error) {
+	if p.IsSetEnableCompress() {
+		if err = oprot.WriteFieldBegin("enable_compress", thrift.BOOL, 10); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteBool(*p.EnableCompress); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 10 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 10 end error: ", p), err)
+}
+
 func (p *TGetSnapshotRequest) String() string {
 	if p == nil {
 		return "<nil>"
@@ -55672,6 +56025,9 @@ func (p *TGetSnapshotRequest) DeepEqual(ano *TGetSnapshotRequest) bool {
 		return false
 	}
 	if !p.Field9DeepEqual(ano.SnapshotType) {
+		return false
+	}
+	if !p.Field10DeepEqual(ano.EnableCompress) {
 		return false
 	}
 	return true
@@ -55785,12 +56141,25 @@ func (p *TGetSnapshotRequest) Field9DeepEqual(src *TSnapshotType) bool {
 	}
 	return true
 }
+func (p *TGetSnapshotRequest) Field10DeepEqual(src *bool) bool {
+
+	if p.EnableCompress == src {
+		return true
+	} else if p.EnableCompress == nil || src == nil {
+		return false
+	}
+	if *p.EnableCompress != *src {
+		return false
+	}
+	return true
+}
 
 type TGetSnapshotResult_ struct {
 	Status        *status.TStatus        `thrift:"status,1,optional" frugal:"1,optional,status.TStatus" json:"status,omitempty"`
 	Meta          []byte                 `thrift:"meta,2,optional" frugal:"2,optional,binary" json:"meta,omitempty"`
 	JobInfo       []byte                 `thrift:"job_info,3,optional" frugal:"3,optional,binary" json:"job_info,omitempty"`
 	MasterAddress *types.TNetworkAddress `thrift:"master_address,4,optional" frugal:"4,optional,types.TNetworkAddress" json:"master_address,omitempty"`
+	Compressed    *bool                  `thrift:"compressed,5,optional" frugal:"5,optional,bool" json:"compressed,omitempty"`
 }
 
 func NewTGetSnapshotResult_() *TGetSnapshotResult_ {
@@ -55835,6 +56204,15 @@ func (p *TGetSnapshotResult_) GetMasterAddress() (v *types.TNetworkAddress) {
 	}
 	return p.MasterAddress
 }
+
+var TGetSnapshotResult__Compressed_DEFAULT bool
+
+func (p *TGetSnapshotResult_) GetCompressed() (v bool) {
+	if !p.IsSetCompressed() {
+		return TGetSnapshotResult__Compressed_DEFAULT
+	}
+	return *p.Compressed
+}
 func (p *TGetSnapshotResult_) SetStatus(val *status.TStatus) {
 	p.Status = val
 }
@@ -55847,12 +56225,16 @@ func (p *TGetSnapshotResult_) SetJobInfo(val []byte) {
 func (p *TGetSnapshotResult_) SetMasterAddress(val *types.TNetworkAddress) {
 	p.MasterAddress = val
 }
+func (p *TGetSnapshotResult_) SetCompressed(val *bool) {
+	p.Compressed = val
+}
 
 var fieldIDToName_TGetSnapshotResult_ = map[int16]string{
 	1: "status",
 	2: "meta",
 	3: "job_info",
 	4: "master_address",
+	5: "compressed",
 }
 
 func (p *TGetSnapshotResult_) IsSetStatus() bool {
@@ -55869,6 +56251,10 @@ func (p *TGetSnapshotResult_) IsSetJobInfo() bool {
 
 func (p *TGetSnapshotResult_) IsSetMasterAddress() bool {
 	return p.MasterAddress != nil
+}
+
+func (p *TGetSnapshotResult_) IsSetCompressed() bool {
+	return p.Compressed != nil
 }
 
 func (p *TGetSnapshotResult_) Read(iprot thrift.TProtocol) (err error) {
@@ -55917,6 +56303,14 @@ func (p *TGetSnapshotResult_) Read(iprot thrift.TProtocol) (err error) {
 		case 4:
 			if fieldTypeId == thrift.STRUCT {
 				if err = p.ReadField4(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 5:
+			if fieldTypeId == thrift.BOOL {
+				if err = p.ReadField5(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -55989,6 +56383,17 @@ func (p *TGetSnapshotResult_) ReadField4(iprot thrift.TProtocol) error {
 	p.MasterAddress = _field
 	return nil
 }
+func (p *TGetSnapshotResult_) ReadField5(iprot thrift.TProtocol) error {
+
+	var _field *bool
+	if v, err := iprot.ReadBool(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Compressed = _field
+	return nil
+}
 
 func (p *TGetSnapshotResult_) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -56010,6 +56415,10 @@ func (p *TGetSnapshotResult_) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField4(oprot); err != nil {
 			fieldId = 4
+			goto WriteFieldError
+		}
+		if err = p.writeField5(oprot); err != nil {
+			fieldId = 5
 			goto WriteFieldError
 		}
 	}
@@ -56106,6 +56515,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 4 end error: ", p), err)
 }
 
+func (p *TGetSnapshotResult_) writeField5(oprot thrift.TProtocol) (err error) {
+	if p.IsSetCompressed() {
+		if err = oprot.WriteFieldBegin("compressed", thrift.BOOL, 5); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteBool(*p.Compressed); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 5 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 5 end error: ", p), err)
+}
+
 func (p *TGetSnapshotResult_) String() string {
 	if p == nil {
 		return "<nil>"
@@ -56130,6 +56558,9 @@ func (p *TGetSnapshotResult_) DeepEqual(ano *TGetSnapshotResult_) bool {
 		return false
 	}
 	if !p.Field4DeepEqual(ano.MasterAddress) {
+		return false
+	}
+	if !p.Field5DeepEqual(ano.Compressed) {
 		return false
 	}
 	return true
@@ -56159,6 +56590,18 @@ func (p *TGetSnapshotResult_) Field3DeepEqual(src []byte) bool {
 func (p *TGetSnapshotResult_) Field4DeepEqual(src *types.TNetworkAddress) bool {
 
 	if !p.MasterAddress.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+func (p *TGetSnapshotResult_) Field5DeepEqual(src *bool) bool {
+
+	if p.Compressed == src {
+		return true
+	} else if p.Compressed == nil || src == nil {
+		return false
+	}
+	if *p.Compressed != *src {
 		return false
 	}
 	return true
@@ -56434,6 +56877,7 @@ type TRestoreSnapshotRequest struct {
 	CleanTables     *bool             `thrift:"clean_tables,13,optional" frugal:"13,optional,bool" json:"clean_tables,omitempty"`
 	CleanPartitions *bool             `thrift:"clean_partitions,14,optional" frugal:"14,optional,bool" json:"clean_partitions,omitempty"`
 	AtomicRestore   *bool             `thrift:"atomic_restore,15,optional" frugal:"15,optional,bool" json:"atomic_restore,omitempty"`
+	Compressed      *bool             `thrift:"compressed,16,optional" frugal:"16,optional,bool" json:"compressed,omitempty"`
 }
 
 func NewTRestoreSnapshotRequest() *TRestoreSnapshotRequest {
@@ -56577,6 +57021,15 @@ func (p *TRestoreSnapshotRequest) GetAtomicRestore() (v bool) {
 	}
 	return *p.AtomicRestore
 }
+
+var TRestoreSnapshotRequest_Compressed_DEFAULT bool
+
+func (p *TRestoreSnapshotRequest) GetCompressed() (v bool) {
+	if !p.IsSetCompressed() {
+		return TRestoreSnapshotRequest_Compressed_DEFAULT
+	}
+	return *p.Compressed
+}
 func (p *TRestoreSnapshotRequest) SetCluster(val *string) {
 	p.Cluster = val
 }
@@ -56622,6 +57075,9 @@ func (p *TRestoreSnapshotRequest) SetCleanPartitions(val *bool) {
 func (p *TRestoreSnapshotRequest) SetAtomicRestore(val *bool) {
 	p.AtomicRestore = val
 }
+func (p *TRestoreSnapshotRequest) SetCompressed(val *bool) {
+	p.Compressed = val
+}
 
 var fieldIDToName_TRestoreSnapshotRequest = map[int16]string{
 	1:  "cluster",
@@ -56639,6 +57095,7 @@ var fieldIDToName_TRestoreSnapshotRequest = map[int16]string{
 	13: "clean_tables",
 	14: "clean_partitions",
 	15: "atomic_restore",
+	16: "compressed",
 }
 
 func (p *TRestoreSnapshotRequest) IsSetCluster() bool {
@@ -56699,6 +57156,10 @@ func (p *TRestoreSnapshotRequest) IsSetCleanPartitions() bool {
 
 func (p *TRestoreSnapshotRequest) IsSetAtomicRestore() bool {
 	return p.AtomicRestore != nil
+}
+
+func (p *TRestoreSnapshotRequest) IsSetCompressed() bool {
+	return p.Compressed != nil
 }
 
 func (p *TRestoreSnapshotRequest) Read(iprot thrift.TProtocol) (err error) {
@@ -56835,6 +57296,14 @@ func (p *TRestoreSnapshotRequest) Read(iprot thrift.TProtocol) (err error) {
 		case 15:
 			if fieldTypeId == thrift.BOOL {
 				if err = p.ReadField15(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 16:
+			if fieldTypeId == thrift.BOOL {
+				if err = p.ReadField16(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -57064,6 +57533,17 @@ func (p *TRestoreSnapshotRequest) ReadField15(iprot thrift.TProtocol) error {
 	p.AtomicRestore = _field
 	return nil
 }
+func (p *TRestoreSnapshotRequest) ReadField16(iprot thrift.TProtocol) error {
+
+	var _field *bool
+	if v, err := iprot.ReadBool(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Compressed = _field
+	return nil
+}
 
 func (p *TRestoreSnapshotRequest) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -57129,6 +57609,10 @@ func (p *TRestoreSnapshotRequest) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField15(oprot); err != nil {
 			fieldId = 15
+			goto WriteFieldError
+		}
+		if err = p.writeField16(oprot); err != nil {
+			fieldId = 16
 			goto WriteFieldError
 		}
 	}
@@ -57453,6 +57937,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 15 end error: ", p), err)
 }
 
+func (p *TRestoreSnapshotRequest) writeField16(oprot thrift.TProtocol) (err error) {
+	if p.IsSetCompressed() {
+		if err = oprot.WriteFieldBegin("compressed", thrift.BOOL, 16); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteBool(*p.Compressed); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 16 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 16 end error: ", p), err)
+}
+
 func (p *TRestoreSnapshotRequest) String() string {
 	if p == nil {
 		return "<nil>"
@@ -57510,6 +58013,9 @@ func (p *TRestoreSnapshotRequest) DeepEqual(ano *TRestoreSnapshotRequest) bool {
 		return false
 	}
 	if !p.Field15DeepEqual(ano.AtomicRestore) {
+		return false
+	}
+	if !p.Field16DeepEqual(ano.Compressed) {
 		return false
 	}
 	return true
@@ -57683,6 +58189,18 @@ func (p *TRestoreSnapshotRequest) Field15DeepEqual(src *bool) bool {
 		return false
 	}
 	if *p.AtomicRestore != *src {
+		return false
+	}
+	return true
+}
+func (p *TRestoreSnapshotRequest) Field16DeepEqual(src *bool) bool {
+
+	if p.Compressed == src {
+		return true
+	} else if p.Compressed == nil || src == nil {
+		return false
+	}
+	if *p.Compressed != *src {
 		return false
 	}
 	return true

--- a/pkg/rpc/kitex_gen/frontendservice/k-FrontendService.go
+++ b/pkg/rpc/kitex_gen/frontendservice/k-FrontendService.go
@@ -11408,6 +11408,34 @@ func (p *TFragmentInstanceReport) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 3:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField3(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 4:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField4(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -11469,6 +11497,32 @@ func (p *TFragmentInstanceReport) FastReadField2(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TFragmentInstanceReport) FastReadField3(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.LoadedRows = &v
+
+	}
+	return offset, nil
+}
+
+func (p *TFragmentInstanceReport) FastReadField4(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.LoadedBytes = &v
+
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TFragmentInstanceReport) FastWrite(buf []byte) int {
 	return 0
@@ -11479,6 +11533,8 @@ func (p *TFragmentInstanceReport) FastWriteNocopy(buf []byte, binaryWriter bthri
 	offset += bthrift.Binary.WriteStructBegin(buf[offset:], "TFragmentInstanceReport")
 	if p != nil {
 		offset += p.fastWriteField2(buf[offset:], binaryWriter)
+		offset += p.fastWriteField3(buf[offset:], binaryWriter)
+		offset += p.fastWriteField4(buf[offset:], binaryWriter)
 		offset += p.fastWriteField1(buf[offset:], binaryWriter)
 	}
 	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
@@ -11492,6 +11548,8 @@ func (p *TFragmentInstanceReport) BLength() int {
 	if p != nil {
 		l += p.field1Length()
 		l += p.field2Length()
+		l += p.field3Length()
+		l += p.field4Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -11519,6 +11577,28 @@ func (p *TFragmentInstanceReport) fastWriteField2(buf []byte, binaryWriter bthri
 	return offset
 }
 
+func (p *TFragmentInstanceReport) fastWriteField3(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetLoadedRows() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "loaded_rows", thrift.I64, 3)
+		offset += bthrift.Binary.WriteI64(buf[offset:], *p.LoadedRows)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TFragmentInstanceReport) fastWriteField4(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetLoadedBytes() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "loaded_bytes", thrift.I64, 4)
+		offset += bthrift.Binary.WriteI64(buf[offset:], *p.LoadedBytes)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TFragmentInstanceReport) field1Length() int {
 	l := 0
 	if p.IsSetFragmentInstanceId() {
@@ -11534,6 +11614,28 @@ func (p *TFragmentInstanceReport) field2Length() int {
 	if p.IsSetNumFinishedRange() {
 		l += bthrift.Binary.FieldBeginLength("num_finished_range", thrift.I32, 2)
 		l += bthrift.Binary.I32Length(*p.NumFinishedRange)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TFragmentInstanceReport) field3Length() int {
+	l := 0
+	if p.IsSetLoadedRows() {
+		l += bthrift.Binary.FieldBeginLength("loaded_rows", thrift.I64, 3)
+		l += bthrift.Binary.I64Length(*p.LoadedRows)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TFragmentInstanceReport) field4Length() int {
+	l := 0
+	if p.IsSetLoadedBytes() {
+		l += bthrift.Binary.FieldBeginLength("loaded_bytes", thrift.I64, 4)
+		l += bthrift.Binary.I64Length(*p.LoadedBytes)
 
 		l += bthrift.Binary.FieldEndLength()
 	}
@@ -21391,6 +21493,20 @@ func (p *TStreamLoadPutRequest) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 57:
+			if fieldTypeId == thrift.I32 {
+				l, err = p.FastReadField57(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		case 1000:
 			if fieldTypeId == thrift.STRING {
 				l, err = p.FastReadField1000(buf[offset:])
@@ -22251,6 +22367,21 @@ func (p *TStreamLoadPutRequest) FastReadField56(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TStreamLoadPutRequest) FastReadField57(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI32(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+
+		tmp := types.TUniqueKeyUpdateMode(v)
+		p.UniqueKeyUpdateMode = &tmp
+
+	}
+	return offset, nil
+}
+
 func (p *TStreamLoadPutRequest) FastReadField1000(buf []byte) (int, error) {
 	offset := 0
 
@@ -22343,6 +22474,7 @@ func (p *TStreamLoadPutRequest) FastWriteNocopy(buf []byte, binaryWriter bthrift
 		offset += p.fastWriteField47(buf[offset:], binaryWriter)
 		offset += p.fastWriteField50(buf[offset:], binaryWriter)
 		offset += p.fastWriteField56(buf[offset:], binaryWriter)
+		offset += p.fastWriteField57(buf[offset:], binaryWriter)
 		offset += p.fastWriteField1000(buf[offset:], binaryWriter)
 	}
 	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
@@ -22410,6 +22542,7 @@ func (p *TStreamLoadPutRequest) BLength() int {
 		l += p.field54Length()
 		l += p.field55Length()
 		l += p.field56Length()
+		l += p.field57Length()
 		l += p.field1000Length()
 		l += p.field1001Length()
 	}
@@ -23019,6 +23152,17 @@ func (p *TStreamLoadPutRequest) fastWriteField56(buf []byte, binaryWriter bthrif
 	if p.IsSetGroupCommitMode() {
 		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "group_commit_mode", thrift.STRING, 56)
 		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.GroupCommitMode)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TStreamLoadPutRequest) fastWriteField57(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetUniqueKeyUpdateMode() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "unique_key_update_mode", thrift.I32, 57)
+		offset += bthrift.Binary.WriteI32(buf[offset:], int32(*p.UniqueKeyUpdateMode))
 
 		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
 	}
@@ -23644,6 +23788,17 @@ func (p *TStreamLoadPutRequest) field56Length() int {
 	if p.IsSetGroupCommitMode() {
 		l += bthrift.Binary.FieldBeginLength("group_commit_mode", thrift.STRING, 56)
 		l += bthrift.Binary.StringLengthNocopy(*p.GroupCommitMode)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TStreamLoadPutRequest) field57Length() int {
+	l := 0
+	if p.IsSetUniqueKeyUpdateMode() {
+		l += bthrift.Binary.FieldBeginLength("unique_key_update_mode", thrift.I32, 57)
+		l += bthrift.Binary.I32Length(int32(*p.UniqueKeyUpdateMode))
 
 		l += bthrift.Binary.FieldEndLength()
 	}
@@ -33942,6 +34097,20 @@ func (p *TMetadataTableRequestParams) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 13:
+			if fieldTypeId == thrift.STRUCT {
+				l, err = p.FastReadField13(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -34152,6 +34321,19 @@ func (p *TMetadataTableRequestParams) FastReadField12(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TMetadataTableRequestParams) FastReadField13(buf []byte) (int, error) {
+	offset := 0
+
+	tmp := plannodes.NewTPartitionValuesMetadataParams()
+	if l, err := tmp.FastRead(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	p.PartitionValuesMetadataParams = tmp
+	return offset, nil
+}
+
 // for compatibility
 func (p *TMetadataTableRequestParams) FastWrite(buf []byte) int {
 	return 0
@@ -34173,6 +34355,7 @@ func (p *TMetadataTableRequestParams) FastWriteNocopy(buf []byte, binaryWriter b
 		offset += p.fastWriteField10(buf[offset:], binaryWriter)
 		offset += p.fastWriteField11(buf[offset:], binaryWriter)
 		offset += p.fastWriteField12(buf[offset:], binaryWriter)
+		offset += p.fastWriteField13(buf[offset:], binaryWriter)
 	}
 	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
 	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
@@ -34195,6 +34378,7 @@ func (p *TMetadataTableRequestParams) BLength() int {
 		l += p.field10Length()
 		l += p.field11Length()
 		l += p.field12Length()
+		l += p.field13Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -34331,6 +34515,16 @@ func (p *TMetadataTableRequestParams) fastWriteField12(buf []byte, binaryWriter 
 	return offset
 }
 
+func (p *TMetadataTableRequestParams) fastWriteField13(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetPartitionValuesMetadataParams() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "partition_values_metadata_params", thrift.STRUCT, 13)
+		offset += p.PartitionValuesMetadataParams.FastWriteNocopy(buf[offset:], binaryWriter)
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TMetadataTableRequestParams) field1Length() int {
 	l := 0
 	if p.IsSetMetadataType() {
@@ -34452,6 +34646,16 @@ func (p *TMetadataTableRequestParams) field12Length() int {
 	if p.IsSetMetaCacheStatsParams() {
 		l += bthrift.Binary.FieldBeginLength("meta_cache_stats_params", thrift.STRUCT, 12)
 		l += p.MetaCacheStatsParams.BLength()
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TMetadataTableRequestParams) field13Length() int {
+	l := 0
+	if p.IsSetPartitionValuesMetadataParams() {
+		l += bthrift.Binary.FieldBeginLength("partition_values_metadata_params", thrift.STRUCT, 13)
+		l += p.PartitionValuesMetadataParams.BLength()
 		l += bthrift.Binary.FieldEndLength()
 	}
 	return l
@@ -40538,6 +40742,20 @@ func (p *TGetSnapshotRequest) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 10:
+			if fieldTypeId == thrift.BOOL {
+				l, err = p.FastReadField10(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -40692,6 +40910,19 @@ func (p *TGetSnapshotRequest) FastReadField9(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TGetSnapshotRequest) FastReadField10(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadBool(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.EnableCompress = &v
+
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TGetSnapshotRequest) FastWrite(buf []byte) int {
 	return 0
@@ -40701,6 +40932,7 @@ func (p *TGetSnapshotRequest) FastWriteNocopy(buf []byte, binaryWriter bthrift.B
 	offset := 0
 	offset += bthrift.Binary.WriteStructBegin(buf[offset:], "TGetSnapshotRequest")
 	if p != nil {
+		offset += p.fastWriteField10(buf[offset:], binaryWriter)
 		offset += p.fastWriteField1(buf[offset:], binaryWriter)
 		offset += p.fastWriteField2(buf[offset:], binaryWriter)
 		offset += p.fastWriteField3(buf[offset:], binaryWriter)
@@ -40729,6 +40961,7 @@ func (p *TGetSnapshotRequest) BLength() int {
 		l += p.field7Length()
 		l += p.field8Length()
 		l += p.field9Length()
+		l += p.field10Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -40834,6 +41067,17 @@ func (p *TGetSnapshotRequest) fastWriteField9(buf []byte, binaryWriter bthrift.B
 	return offset
 }
 
+func (p *TGetSnapshotRequest) fastWriteField10(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetEnableCompress() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "enable_compress", thrift.BOOL, 10)
+		offset += bthrift.Binary.WriteBool(buf[offset:], *p.EnableCompress)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TGetSnapshotRequest) field1Length() int {
 	l := 0
 	if p.IsSetCluster() {
@@ -40933,6 +41177,17 @@ func (p *TGetSnapshotRequest) field9Length() int {
 	return l
 }
 
+func (p *TGetSnapshotRequest) field10Length() int {
+	l := 0
+	if p.IsSetEnableCompress() {
+		l += bthrift.Binary.FieldBeginLength("enable_compress", thrift.BOOL, 10)
+		l += bthrift.Binary.BoolLength(*p.EnableCompress)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
 func (p *TGetSnapshotResult_) FastRead(buf []byte) (int, error) {
 	var err error
 	var offset int
@@ -41000,6 +41255,20 @@ func (p *TGetSnapshotResult_) FastRead(buf []byte) (int, error) {
 		case 4:
 			if fieldTypeId == thrift.STRUCT {
 				l, err = p.FastReadField4(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 5:
+			if fieldTypeId == thrift.BOOL {
+				l, err = p.FastReadField5(buf[offset:])
 				offset += l
 				if err != nil {
 					goto ReadFieldError
@@ -41100,6 +41369,19 @@ func (p *TGetSnapshotResult_) FastReadField4(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TGetSnapshotResult_) FastReadField5(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadBool(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.Compressed = &v
+
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TGetSnapshotResult_) FastWrite(buf []byte) int {
 	return 0
@@ -41109,6 +41391,7 @@ func (p *TGetSnapshotResult_) FastWriteNocopy(buf []byte, binaryWriter bthrift.B
 	offset := 0
 	offset += bthrift.Binary.WriteStructBegin(buf[offset:], "TGetSnapshotResult")
 	if p != nil {
+		offset += p.fastWriteField5(buf[offset:], binaryWriter)
 		offset += p.fastWriteField1(buf[offset:], binaryWriter)
 		offset += p.fastWriteField2(buf[offset:], binaryWriter)
 		offset += p.fastWriteField3(buf[offset:], binaryWriter)
@@ -41127,6 +41410,7 @@ func (p *TGetSnapshotResult_) BLength() int {
 		l += p.field2Length()
 		l += p.field3Length()
 		l += p.field4Length()
+		l += p.field5Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -41175,6 +41459,17 @@ func (p *TGetSnapshotResult_) fastWriteField4(buf []byte, binaryWriter bthrift.B
 	return offset
 }
 
+func (p *TGetSnapshotResult_) fastWriteField5(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetCompressed() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "compressed", thrift.BOOL, 5)
+		offset += bthrift.Binary.WriteBool(buf[offset:], *p.Compressed)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TGetSnapshotResult_) field1Length() int {
 	l := 0
 	if p.IsSetStatus() {
@@ -41212,6 +41507,17 @@ func (p *TGetSnapshotResult_) field4Length() int {
 	if p.IsSetMasterAddress() {
 		l += bthrift.Binary.FieldBeginLength("master_address", thrift.STRUCT, 4)
 		l += p.MasterAddress.BLength()
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetSnapshotResult_) field5Length() int {
+	l := 0
+	if p.IsSetCompressed() {
+		l += bthrift.Binary.FieldBeginLength("compressed", thrift.BOOL, 5)
+		l += bthrift.Binary.BoolLength(*p.Compressed)
+
 		l += bthrift.Binary.FieldEndLength()
 	}
 	return l
@@ -41633,6 +41939,20 @@ func (p *TRestoreSnapshotRequest) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 16:
+			if fieldTypeId == thrift.BOOL {
+				l, err = p.FastReadField16(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -41906,6 +42226,19 @@ func (p *TRestoreSnapshotRequest) FastReadField15(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TRestoreSnapshotRequest) FastReadField16(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadBool(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.Compressed = &v
+
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TRestoreSnapshotRequest) FastWrite(buf []byte) int {
 	return 0
@@ -41918,6 +42251,7 @@ func (p *TRestoreSnapshotRequest) FastWriteNocopy(buf []byte, binaryWriter bthri
 		offset += p.fastWriteField13(buf[offset:], binaryWriter)
 		offset += p.fastWriteField14(buf[offset:], binaryWriter)
 		offset += p.fastWriteField15(buf[offset:], binaryWriter)
+		offset += p.fastWriteField16(buf[offset:], binaryWriter)
 		offset += p.fastWriteField1(buf[offset:], binaryWriter)
 		offset += p.fastWriteField2(buf[offset:], binaryWriter)
 		offset += p.fastWriteField3(buf[offset:], binaryWriter)
@@ -41955,6 +42289,7 @@ func (p *TRestoreSnapshotRequest) BLength() int {
 		l += p.field13Length()
 		l += p.field14Length()
 		l += p.field15Length()
+		l += p.field16Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -42144,6 +42479,17 @@ func (p *TRestoreSnapshotRequest) fastWriteField15(buf []byte, binaryWriter bthr
 	return offset
 }
 
+func (p *TRestoreSnapshotRequest) fastWriteField16(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetCompressed() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "compressed", thrift.BOOL, 16)
+		offset += bthrift.Binary.WriteBool(buf[offset:], *p.Compressed)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TRestoreSnapshotRequest) field1Length() int {
 	l := 0
 	if p.IsSetCluster() {
@@ -42313,6 +42659,17 @@ func (p *TRestoreSnapshotRequest) field15Length() int {
 	if p.IsSetAtomicRestore() {
 		l += bthrift.Binary.FieldBeginLength("atomic_restore", thrift.BOOL, 15)
 		l += bthrift.Binary.BoolLength(*p.AtomicRestore)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TRestoreSnapshotRequest) field16Length() int {
+	l := 0
+	if p.IsSetCompressed() {
+		l += bthrift.Binary.FieldBeginLength("compressed", thrift.BOOL, 16)
+		l += bthrift.Binary.BoolLength(*p.Compressed)
 
 		l += bthrift.Binary.FieldEndLength()
 	}

--- a/pkg/rpc/kitex_gen/heartbeatservice/HeartbeatService.go
+++ b/pkg/rpc/kitex_gen/heartbeatservice/HeartbeatService.go
@@ -262,17 +262,18 @@ func (p *TFrontendInfo) Field2DeepEqual(src *int64) bool {
 }
 
 type TMasterInfo struct {
-	NetworkAddress      *types.TNetworkAddress `thrift:"network_address,1,required" frugal:"1,required,types.TNetworkAddress" json:"network_address"`
-	ClusterId           types.TClusterId       `thrift:"cluster_id,2,required" frugal:"2,required,i32" json:"cluster_id"`
-	Epoch               types.TEpoch           `thrift:"epoch,3,required" frugal:"3,required,i64" json:"epoch"`
-	Token               *string                `thrift:"token,4,optional" frugal:"4,optional,string" json:"token,omitempty"`
-	BackendIp           *string                `thrift:"backend_ip,5,optional" frugal:"5,optional,string" json:"backend_ip,omitempty"`
-	HttpPort            *types.TPort           `thrift:"http_port,6,optional" frugal:"6,optional,i32" json:"http_port,omitempty"`
-	HeartbeatFlags      *int64                 `thrift:"heartbeat_flags,7,optional" frugal:"7,optional,i64" json:"heartbeat_flags,omitempty"`
-	BackendId           *int64                 `thrift:"backend_id,8,optional" frugal:"8,optional,i64" json:"backend_id,omitempty"`
-	FrontendInfos       []*TFrontendInfo       `thrift:"frontend_infos,9,optional" frugal:"9,optional,list<TFrontendInfo>" json:"frontend_infos,omitempty"`
-	MetaServiceEndpoint *string                `thrift:"meta_service_endpoint,10,optional" frugal:"10,optional,string" json:"meta_service_endpoint,omitempty"`
-	CloudUniqueId       *string                `thrift:"cloud_unique_id,11,optional" frugal:"11,optional,string" json:"cloud_unique_id,omitempty"`
+	NetworkAddress                 *types.TNetworkAddress `thrift:"network_address,1,required" frugal:"1,required,types.TNetworkAddress" json:"network_address"`
+	ClusterId                      types.TClusterId       `thrift:"cluster_id,2,required" frugal:"2,required,i32" json:"cluster_id"`
+	Epoch                          types.TEpoch           `thrift:"epoch,3,required" frugal:"3,required,i64" json:"epoch"`
+	Token                          *string                `thrift:"token,4,optional" frugal:"4,optional,string" json:"token,omitempty"`
+	BackendIp                      *string                `thrift:"backend_ip,5,optional" frugal:"5,optional,string" json:"backend_ip,omitempty"`
+	HttpPort                       *types.TPort           `thrift:"http_port,6,optional" frugal:"6,optional,i32" json:"http_port,omitempty"`
+	HeartbeatFlags                 *int64                 `thrift:"heartbeat_flags,7,optional" frugal:"7,optional,i64" json:"heartbeat_flags,omitempty"`
+	BackendId                      *int64                 `thrift:"backend_id,8,optional" frugal:"8,optional,i64" json:"backend_id,omitempty"`
+	FrontendInfos                  []*TFrontendInfo       `thrift:"frontend_infos,9,optional" frugal:"9,optional,list<TFrontendInfo>" json:"frontend_infos,omitempty"`
+	MetaServiceEndpoint            *string                `thrift:"meta_service_endpoint,10,optional" frugal:"10,optional,string" json:"meta_service_endpoint,omitempty"`
+	CloudUniqueId                  *string                `thrift:"cloud_unique_id,11,optional" frugal:"11,optional,string" json:"cloud_unique_id,omitempty"`
+	TabletReportInactiveDurationMs *int64                 `thrift:"tablet_report_inactive_duration_ms,12,optional" frugal:"12,optional,i64" json:"tablet_report_inactive_duration_ms,omitempty"`
 }
 
 func NewTMasterInfo() *TMasterInfo {
@@ -370,6 +371,15 @@ func (p *TMasterInfo) GetCloudUniqueId() (v string) {
 	}
 	return *p.CloudUniqueId
 }
+
+var TMasterInfo_TabletReportInactiveDurationMs_DEFAULT int64
+
+func (p *TMasterInfo) GetTabletReportInactiveDurationMs() (v int64) {
+	if !p.IsSetTabletReportInactiveDurationMs() {
+		return TMasterInfo_TabletReportInactiveDurationMs_DEFAULT
+	}
+	return *p.TabletReportInactiveDurationMs
+}
 func (p *TMasterInfo) SetNetworkAddress(val *types.TNetworkAddress) {
 	p.NetworkAddress = val
 }
@@ -403,6 +413,9 @@ func (p *TMasterInfo) SetMetaServiceEndpoint(val *string) {
 func (p *TMasterInfo) SetCloudUniqueId(val *string) {
 	p.CloudUniqueId = val
 }
+func (p *TMasterInfo) SetTabletReportInactiveDurationMs(val *int64) {
+	p.TabletReportInactiveDurationMs = val
+}
 
 var fieldIDToName_TMasterInfo = map[int16]string{
 	1:  "network_address",
@@ -416,6 +429,7 @@ var fieldIDToName_TMasterInfo = map[int16]string{
 	9:  "frontend_infos",
 	10: "meta_service_endpoint",
 	11: "cloud_unique_id",
+	12: "tablet_report_inactive_duration_ms",
 }
 
 func (p *TMasterInfo) IsSetNetworkAddress() bool {
@@ -452,6 +466,10 @@ func (p *TMasterInfo) IsSetMetaServiceEndpoint() bool {
 
 func (p *TMasterInfo) IsSetCloudUniqueId() bool {
 	return p.CloudUniqueId != nil
+}
+
+func (p *TMasterInfo) IsSetTabletReportInactiveDurationMs() bool {
+	return p.TabletReportInactiveDurationMs != nil
 }
 
 func (p *TMasterInfo) Read(iprot thrift.TProtocol) (err error) {
@@ -562,6 +580,14 @@ func (p *TMasterInfo) Read(iprot thrift.TProtocol) (err error) {
 		case 11:
 			if fieldTypeId == thrift.STRING {
 				if err = p.ReadField11(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 12:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField12(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -742,6 +768,17 @@ func (p *TMasterInfo) ReadField11(iprot thrift.TProtocol) error {
 	p.CloudUniqueId = _field
 	return nil
 }
+func (p *TMasterInfo) ReadField12(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.TabletReportInactiveDurationMs = _field
+	return nil
+}
 
 func (p *TMasterInfo) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -791,6 +828,10 @@ func (p *TMasterInfo) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField11(oprot); err != nil {
 			fieldId = 11
+			goto WriteFieldError
+		}
+		if err = p.writeField12(oprot); err != nil {
+			fieldId = 12
 			goto WriteFieldError
 		}
 	}
@@ -1022,6 +1063,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 11 end error: ", p), err)
 }
 
+func (p *TMasterInfo) writeField12(oprot thrift.TProtocol) (err error) {
+	if p.IsSetTabletReportInactiveDurationMs() {
+		if err = oprot.WriteFieldBegin("tablet_report_inactive_duration_ms", thrift.I64, 12); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.TabletReportInactiveDurationMs); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 12 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 12 end error: ", p), err)
+}
+
 func (p *TMasterInfo) String() string {
 	if p == nil {
 		return "<nil>"
@@ -1067,6 +1127,9 @@ func (p *TMasterInfo) DeepEqual(ano *TMasterInfo) bool {
 		return false
 	}
 	if !p.Field11DeepEqual(ano.CloudUniqueId) {
+		return false
+	}
+	if !p.Field12DeepEqual(ano.TabletReportInactiveDurationMs) {
 		return false
 	}
 	return true
@@ -1186,6 +1249,18 @@ func (p *TMasterInfo) Field11DeepEqual(src *string) bool {
 		return false
 	}
 	if strings.Compare(*p.CloudUniqueId, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TMasterInfo) Field12DeepEqual(src *int64) bool {
+
+	if p.TabletReportInactiveDurationMs == src {
+		return true
+	} else if p.TabletReportInactiveDurationMs == nil || src == nil {
+		return false
+	}
+	if *p.TabletReportInactiveDurationMs != *src {
 		return false
 	}
 	return true

--- a/pkg/rpc/kitex_gen/heartbeatservice/k-HeartbeatService.go
+++ b/pkg/rpc/kitex_gen/heartbeatservice/k-HeartbeatService.go
@@ -394,6 +394,20 @@ func (p *TMasterInfo) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 12:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField12(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -604,6 +618,19 @@ func (p *TMasterInfo) FastReadField11(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TMasterInfo) FastReadField12(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.TabletReportInactiveDurationMs = &v
+
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TMasterInfo) FastWrite(buf []byte) int {
 	return 0
@@ -618,6 +645,7 @@ func (p *TMasterInfo) FastWriteNocopy(buf []byte, binaryWriter bthrift.BinaryWri
 		offset += p.fastWriteField6(buf[offset:], binaryWriter)
 		offset += p.fastWriteField7(buf[offset:], binaryWriter)
 		offset += p.fastWriteField8(buf[offset:], binaryWriter)
+		offset += p.fastWriteField12(buf[offset:], binaryWriter)
 		offset += p.fastWriteField1(buf[offset:], binaryWriter)
 		offset += p.fastWriteField4(buf[offset:], binaryWriter)
 		offset += p.fastWriteField5(buf[offset:], binaryWriter)
@@ -645,6 +673,7 @@ func (p *TMasterInfo) BLength() int {
 		l += p.field9Length()
 		l += p.field10Length()
 		l += p.field11Length()
+		l += p.field12Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -772,6 +801,17 @@ func (p *TMasterInfo) fastWriteField11(buf []byte, binaryWriter bthrift.BinaryWr
 	return offset
 }
 
+func (p *TMasterInfo) fastWriteField12(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetTabletReportInactiveDurationMs() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "tablet_report_inactive_duration_ms", thrift.I64, 12)
+		offset += bthrift.Binary.WriteI64(buf[offset:], *p.TabletReportInactiveDurationMs)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TMasterInfo) field1Length() int {
 	l := 0
 	l += bthrift.Binary.FieldBeginLength("network_address", thrift.STRUCT, 1)
@@ -883,6 +923,17 @@ func (p *TMasterInfo) field11Length() int {
 	if p.IsSetCloudUniqueId() {
 		l += bthrift.Binary.FieldBeginLength("cloud_unique_id", thrift.STRING, 11)
 		l += bthrift.Binary.StringLengthNocopy(*p.CloudUniqueId)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TMasterInfo) field12Length() int {
+	l := 0
+	if p.IsSetTabletReportInactiveDurationMs() {
+		l += bthrift.Binary.FieldBeginLength("tablet_report_inactive_duration_ms", thrift.I64, 12)
+		l += bthrift.Binary.I64Length(*p.TabletReportInactiveDurationMs)
 
 		l += bthrift.Binary.FieldEndLength()
 	}

--- a/pkg/rpc/kitex_gen/masterservice/MasterService.go
+++ b/pkg/rpc/kitex_gen/masterservice/MasterService.go
@@ -4720,6 +4720,7 @@ type TReportRequest struct {
 	NumCores                 int32                                 `thrift:"num_cores,11" frugal:"11,default,i32" json:"num_cores"`
 	PipelineExecutorSize     int32                                 `thrift:"pipeline_executor_size,12" frugal:"12,default,i32" json:"pipeline_executor_size"`
 	PartitionsVersion        map[types.TPartitionId]types.TVersion `thrift:"partitions_version,13,optional" frugal:"13,optional,map<i64:i64>" json:"partitions_version,omitempty"`
+	NumTablets               *int64                                `thrift:"num_tablets,14,optional" frugal:"14,optional,i64" json:"num_tablets,omitempty"`
 }
 
 func NewTReportRequest() *TReportRequest {
@@ -4835,6 +4836,15 @@ func (p *TReportRequest) GetPartitionsVersion() (v map[types.TPartitionId]types.
 	}
 	return p.PartitionsVersion
 }
+
+var TReportRequest_NumTablets_DEFAULT int64
+
+func (p *TReportRequest) GetNumTablets() (v int64) {
+	if !p.IsSetNumTablets() {
+		return TReportRequest_NumTablets_DEFAULT
+	}
+	return *p.NumTablets
+}
 func (p *TReportRequest) SetBackend(val *types.TBackend) {
 	p.Backend = val
 }
@@ -4874,6 +4884,9 @@ func (p *TReportRequest) SetPipelineExecutorSize(val int32) {
 func (p *TReportRequest) SetPartitionsVersion(val map[types.TPartitionId]types.TVersion) {
 	p.PartitionsVersion = val
 }
+func (p *TReportRequest) SetNumTablets(val *int64) {
+	p.NumTablets = val
+}
 
 var fieldIDToName_TReportRequest = map[int16]string{
 	1:  "backend",
@@ -4889,6 +4902,7 @@ var fieldIDToName_TReportRequest = map[int16]string{
 	11: "num_cores",
 	12: "pipeline_executor_size",
 	13: "partitions_version",
+	14: "num_tablets",
 }
 
 func (p *TReportRequest) IsSetBackend() bool {
@@ -4933,6 +4947,10 @@ func (p *TReportRequest) IsSetResource() bool {
 
 func (p *TReportRequest) IsSetPartitionsVersion() bool {
 	return p.PartitionsVersion != nil
+}
+
+func (p *TReportRequest) IsSetNumTablets() bool {
+	return p.NumTablets != nil
 }
 
 func (p *TReportRequest) Read(iprot thrift.TProtocol) (err error) {
@@ -5055,6 +5073,14 @@ func (p *TReportRequest) Read(iprot thrift.TProtocol) (err error) {
 		case 13:
 			if fieldTypeId == thrift.MAP {
 				if err = p.ReadField13(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 14:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField14(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -5355,6 +5381,17 @@ func (p *TReportRequest) ReadField13(iprot thrift.TProtocol) error {
 	p.PartitionsVersion = _field
 	return nil
 }
+func (p *TReportRequest) ReadField14(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.NumTablets = _field
+	return nil
+}
 
 func (p *TReportRequest) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -5412,6 +5449,10 @@ func (p *TReportRequest) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField13(oprot); err != nil {
 			fieldId = 13
+			goto WriteFieldError
+		}
+		if err = p.writeField14(oprot); err != nil {
+			fieldId = 14
 			goto WriteFieldError
 		}
 	}
@@ -5761,6 +5802,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 13 end error: ", p), err)
 }
 
+func (p *TReportRequest) writeField14(oprot thrift.TProtocol) (err error) {
+	if p.IsSetNumTablets() {
+		if err = oprot.WriteFieldBegin("num_tablets", thrift.I64, 14); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.NumTablets); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 14 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 14 end error: ", p), err)
+}
+
 func (p *TReportRequest) String() string {
 	if p == nil {
 		return "<nil>"
@@ -5812,6 +5872,9 @@ func (p *TReportRequest) DeepEqual(ano *TReportRequest) bool {
 		return false
 	}
 	if !p.Field13DeepEqual(ano.PartitionsVersion) {
+		return false
+	}
+	if !p.Field14DeepEqual(ano.NumTablets) {
 		return false
 	}
 	return true
@@ -5968,6 +6031,18 @@ func (p *TReportRequest) Field13DeepEqual(src map[types.TPartitionId]types.TVers
 		if v != _src {
 			return false
 		}
+	}
+	return true
+}
+func (p *TReportRequest) Field14DeepEqual(src *int64) bool {
+
+	if p.NumTablets == src {
+		return true
+	} else if p.NumTablets == nil || src == nil {
+		return false
+	}
+	if *p.NumTablets != *src {
+		return false
 	}
 	return true
 }

--- a/pkg/rpc/kitex_gen/masterservice/k-MasterService.go
+++ b/pkg/rpc/kitex_gen/masterservice/k-MasterService.go
@@ -3788,6 +3788,20 @@ func (p *TReportRequest) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 14:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField14(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -4157,6 +4171,19 @@ func (p *TReportRequest) FastReadField13(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TReportRequest) FastReadField14(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.NumTablets = &v
+
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TReportRequest) FastWrite(buf []byte) int {
 	return 0
@@ -4171,6 +4198,7 @@ func (p *TReportRequest) FastWriteNocopy(buf []byte, binaryWriter bthrift.Binary
 		offset += p.fastWriteField8(buf[offset:], binaryWriter)
 		offset += p.fastWriteField11(buf[offset:], binaryWriter)
 		offset += p.fastWriteField12(buf[offset:], binaryWriter)
+		offset += p.fastWriteField14(buf[offset:], binaryWriter)
 		offset += p.fastWriteField1(buf[offset:], binaryWriter)
 		offset += p.fastWriteField3(buf[offset:], binaryWriter)
 		offset += p.fastWriteField4(buf[offset:], binaryWriter)
@@ -4202,6 +4230,7 @@ func (p *TReportRequest) BLength() int {
 		l += p.field11Length()
 		l += p.field12Length()
 		l += p.field13Length()
+		l += p.field14Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -4428,6 +4457,17 @@ func (p *TReportRequest) fastWriteField13(buf []byte, binaryWriter bthrift.Binar
 	return offset
 }
 
+func (p *TReportRequest) fastWriteField14(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetNumTablets() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "num_tablets", thrift.I64, 14)
+		offset += bthrift.Binary.WriteI64(buf[offset:], *p.NumTablets)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TReportRequest) field1Length() int {
 	l := 0
 	l += bthrift.Binary.FieldBeginLength("backend", thrift.STRUCT, 1)
@@ -4605,6 +4645,17 @@ func (p *TReportRequest) field13Length() int {
 		var tmpV types.TVersion
 		l += (bthrift.Binary.I64Length(int64(tmpK)) + bthrift.Binary.I64Length(int64(tmpV))) * len(p.PartitionsVersion)
 		l += bthrift.Binary.MapEndLength()
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TReportRequest) field14Length() int {
+	l := 0
+	if p.IsSetNumTablets() {
+		l += bthrift.Binary.FieldBeginLength("num_tablets", thrift.I64, 14)
+		l += bthrift.Binary.I64Length(*p.NumTablets)
+
 		l += bthrift.Binary.FieldEndLength()
 	}
 	return l

--- a/pkg/rpc/kitex_gen/palointernalservice/PaloInternalService.go
+++ b/pkg/rpc/kitex_gen/palointernalservice/PaloInternalService.go
@@ -1740,9 +1740,9 @@ type TQueryOptions struct {
 	EnableNoNeedReadDataOpt                     bool            `thrift:"enable_no_need_read_data_opt,116,optional" frugal:"116,optional,bool" json:"enable_no_need_read_data_opt,omitempty"`
 	ReadCsvEmptyLineAsNull                      bool            `thrift:"read_csv_empty_line_as_null,117,optional" frugal:"117,optional,bool" json:"read_csv_empty_line_as_null,omitempty"`
 	SerdeDialect                                TSerdeDialect   `thrift:"serde_dialect,118,optional" frugal:"118,optional,TSerdeDialect" json:"serde_dialect,omitempty"`
-	KeepCarriageReturn                          bool            `thrift:"keep_carriage_return,119,optional" frugal:"119,optional,bool" json:"keep_carriage_return,omitempty"`
-	EnableMatchWithoutInvertedIndex             bool            `thrift:"enable_match_without_inverted_index,120,optional" frugal:"120,optional,bool" json:"enable_match_without_inverted_index,omitempty"`
-	EnableFallbackOnMissingInvertedIndex        bool            `thrift:"enable_fallback_on_missing_inverted_index,121,optional" frugal:"121,optional,bool" json:"enable_fallback_on_missing_inverted_index,omitempty"`
+	EnableMatchWithoutInvertedIndex             bool            `thrift:"enable_match_without_inverted_index,119,optional" frugal:"119,optional,bool" json:"enable_match_without_inverted_index,omitempty"`
+	EnableFallbackOnMissingInvertedIndex        bool            `thrift:"enable_fallback_on_missing_inverted_index,120,optional" frugal:"120,optional,bool" json:"enable_fallback_on_missing_inverted_index,omitempty"`
+	KeepCarriageReturn                          bool            `thrift:"keep_carriage_return,121,optional" frugal:"121,optional,bool" json:"keep_carriage_return,omitempty"`
 	RuntimeBloomFilterMinSize                   int32           `thrift:"runtime_bloom_filter_min_size,122,optional" frugal:"122,optional,i32" json:"runtime_bloom_filter_min_size,omitempty"`
 	HiveParquetUseColumnNames                   bool            `thrift:"hive_parquet_use_column_names,123,optional" frugal:"123,optional,bool" json:"hive_parquet_use_column_names,omitempty"`
 	HiveOrcUseColumnNames                       bool            `thrift:"hive_orc_use_column_names,124,optional" frugal:"124,optional,bool" json:"hive_orc_use_column_names,omitempty"`
@@ -1756,6 +1756,9 @@ type TQueryOptions struct {
 	ParallelPrepareThreshold                    int32           `thrift:"parallel_prepare_threshold,132,optional" frugal:"132,optional,i32" json:"parallel_prepare_threshold,omitempty"`
 	PartitionTopnMaxPartitions                  int32           `thrift:"partition_topn_max_partitions,133,optional" frugal:"133,optional,i32" json:"partition_topn_max_partitions,omitempty"`
 	PartitionTopnPrePartitionRows               int32           `thrift:"partition_topn_pre_partition_rows,134,optional" frugal:"134,optional,i32" json:"partition_topn_pre_partition_rows,omitempty"`
+	EnableParallelOutfile                       bool            `thrift:"enable_parallel_outfile,135,optional" frugal:"135,optional,bool" json:"enable_parallel_outfile,omitempty"`
+	EnablePhraseQuerySequentialOpt              bool            `thrift:"enable_phrase_query_sequential_opt,136,optional" frugal:"136,optional,bool" json:"enable_phrase_query_sequential_opt,omitempty"`
+	EnableAutoCreateWhenOverwrite               bool            `thrift:"enable_auto_create_when_overwrite,137,optional" frugal:"137,optional,bool" json:"enable_auto_create_when_overwrite,omitempty"`
 	DisableFileCache                            bool            `thrift:"disable_file_cache,1000,optional" frugal:"1000,optional,bool" json:"disable_file_cache,omitempty"`
 }
 
@@ -1860,9 +1863,9 @@ func NewTQueryOptions() *TQueryOptions {
 		EnableNoNeedReadDataOpt:                     true,
 		ReadCsvEmptyLineAsNull:                      false,
 		SerdeDialect:                                TSerdeDialect_DORIS,
-		KeepCarriageReturn:                          false,
 		EnableMatchWithoutInvertedIndex:             true,
 		EnableFallbackOnMissingInvertedIndex:        true,
+		KeepCarriageReturn:                          false,
 		RuntimeBloomFilterMinSize:                   1048576,
 		HiveParquetUseColumnNames:                   true,
 		HiveOrcUseColumnNames:                       true,
@@ -1876,6 +1879,9 @@ func NewTQueryOptions() *TQueryOptions {
 		ParallelPrepareThreshold:                    0,
 		PartitionTopnMaxPartitions:                  1024,
 		PartitionTopnPrePartitionRows:               1000,
+		EnableParallelOutfile:                       false,
+		EnablePhraseQuerySequentialOpt:              true,
+		EnableAutoCreateWhenOverwrite:               false,
 		DisableFileCache:                            false,
 	}
 }
@@ -1979,9 +1985,9 @@ func (p *TQueryOptions) InitDefault() {
 	p.EnableNoNeedReadDataOpt = true
 	p.ReadCsvEmptyLineAsNull = false
 	p.SerdeDialect = TSerdeDialect_DORIS
-	p.KeepCarriageReturn = false
 	p.EnableMatchWithoutInvertedIndex = true
 	p.EnableFallbackOnMissingInvertedIndex = true
+	p.KeepCarriageReturn = false
 	p.RuntimeBloomFilterMinSize = 1048576
 	p.HiveParquetUseColumnNames = true
 	p.HiveOrcUseColumnNames = true
@@ -1995,6 +2001,9 @@ func (p *TQueryOptions) InitDefault() {
 	p.ParallelPrepareThreshold = 0
 	p.PartitionTopnMaxPartitions = 1024
 	p.PartitionTopnPrePartitionRows = 1000
+	p.EnableParallelOutfile = false
+	p.EnablePhraseQuerySequentialOpt = true
+	p.EnableAutoCreateWhenOverwrite = false
 	p.DisableFileCache = false
 }
 
@@ -2979,15 +2988,6 @@ func (p *TQueryOptions) GetSerdeDialect() (v TSerdeDialect) {
 	return p.SerdeDialect
 }
 
-var TQueryOptions_KeepCarriageReturn_DEFAULT bool = false
-
-func (p *TQueryOptions) GetKeepCarriageReturn() (v bool) {
-	if !p.IsSetKeepCarriageReturn() {
-		return TQueryOptions_KeepCarriageReturn_DEFAULT
-	}
-	return p.KeepCarriageReturn
-}
-
 var TQueryOptions_EnableMatchWithoutInvertedIndex_DEFAULT bool = true
 
 func (p *TQueryOptions) GetEnableMatchWithoutInvertedIndex() (v bool) {
@@ -3004,6 +3004,15 @@ func (p *TQueryOptions) GetEnableFallbackOnMissingInvertedIndex() (v bool) {
 		return TQueryOptions_EnableFallbackOnMissingInvertedIndex_DEFAULT
 	}
 	return p.EnableFallbackOnMissingInvertedIndex
+}
+
+var TQueryOptions_KeepCarriageReturn_DEFAULT bool = false
+
+func (p *TQueryOptions) GetKeepCarriageReturn() (v bool) {
+	if !p.IsSetKeepCarriageReturn() {
+		return TQueryOptions_KeepCarriageReturn_DEFAULT
+	}
+	return p.KeepCarriageReturn
 }
 
 var TQueryOptions_RuntimeBloomFilterMinSize_DEFAULT int32 = 1048576
@@ -3121,6 +3130,33 @@ func (p *TQueryOptions) GetPartitionTopnPrePartitionRows() (v int32) {
 		return TQueryOptions_PartitionTopnPrePartitionRows_DEFAULT
 	}
 	return p.PartitionTopnPrePartitionRows
+}
+
+var TQueryOptions_EnableParallelOutfile_DEFAULT bool = false
+
+func (p *TQueryOptions) GetEnableParallelOutfile() (v bool) {
+	if !p.IsSetEnableParallelOutfile() {
+		return TQueryOptions_EnableParallelOutfile_DEFAULT
+	}
+	return p.EnableParallelOutfile
+}
+
+var TQueryOptions_EnablePhraseQuerySequentialOpt_DEFAULT bool = true
+
+func (p *TQueryOptions) GetEnablePhraseQuerySequentialOpt() (v bool) {
+	if !p.IsSetEnablePhraseQuerySequentialOpt() {
+		return TQueryOptions_EnablePhraseQuerySequentialOpt_DEFAULT
+	}
+	return p.EnablePhraseQuerySequentialOpt
+}
+
+var TQueryOptions_EnableAutoCreateWhenOverwrite_DEFAULT bool = false
+
+func (p *TQueryOptions) GetEnableAutoCreateWhenOverwrite() (v bool) {
+	if !p.IsSetEnableAutoCreateWhenOverwrite() {
+		return TQueryOptions_EnableAutoCreateWhenOverwrite_DEFAULT
+	}
+	return p.EnableAutoCreateWhenOverwrite
 }
 
 var TQueryOptions_DisableFileCache_DEFAULT bool = false
@@ -3458,14 +3494,14 @@ func (p *TQueryOptions) SetReadCsvEmptyLineAsNull(val bool) {
 func (p *TQueryOptions) SetSerdeDialect(val TSerdeDialect) {
 	p.SerdeDialect = val
 }
-func (p *TQueryOptions) SetKeepCarriageReturn(val bool) {
-	p.KeepCarriageReturn = val
-}
 func (p *TQueryOptions) SetEnableMatchWithoutInvertedIndex(val bool) {
 	p.EnableMatchWithoutInvertedIndex = val
 }
 func (p *TQueryOptions) SetEnableFallbackOnMissingInvertedIndex(val bool) {
 	p.EnableFallbackOnMissingInvertedIndex = val
+}
+func (p *TQueryOptions) SetKeepCarriageReturn(val bool) {
+	p.KeepCarriageReturn = val
 }
 func (p *TQueryOptions) SetRuntimeBloomFilterMinSize(val int32) {
 	p.RuntimeBloomFilterMinSize = val
@@ -3505,6 +3541,15 @@ func (p *TQueryOptions) SetPartitionTopnMaxPartitions(val int32) {
 }
 func (p *TQueryOptions) SetPartitionTopnPrePartitionRows(val int32) {
 	p.PartitionTopnPrePartitionRows = val
+}
+func (p *TQueryOptions) SetEnableParallelOutfile(val bool) {
+	p.EnableParallelOutfile = val
+}
+func (p *TQueryOptions) SetEnablePhraseQuerySequentialOpt(val bool) {
+	p.EnablePhraseQuerySequentialOpt = val
+}
+func (p *TQueryOptions) SetEnableAutoCreateWhenOverwrite(val bool) {
+	p.EnableAutoCreateWhenOverwrite = val
 }
 func (p *TQueryOptions) SetDisableFileCache(val bool) {
 	p.DisableFileCache = val
@@ -3620,9 +3665,9 @@ var fieldIDToName_TQueryOptions = map[int16]string{
 	116:  "enable_no_need_read_data_opt",
 	117:  "read_csv_empty_line_as_null",
 	118:  "serde_dialect",
-	119:  "keep_carriage_return",
-	120:  "enable_match_without_inverted_index",
-	121:  "enable_fallback_on_missing_inverted_index",
+	119:  "enable_match_without_inverted_index",
+	120:  "enable_fallback_on_missing_inverted_index",
+	121:  "keep_carriage_return",
 	122:  "runtime_bloom_filter_min_size",
 	123:  "hive_parquet_use_column_names",
 	124:  "hive_orc_use_column_names",
@@ -3636,6 +3681,9 @@ var fieldIDToName_TQueryOptions = map[int16]string{
 	132:  "parallel_prepare_threshold",
 	133:  "partition_topn_max_partitions",
 	134:  "partition_topn_pre_partition_rows",
+	135:  "enable_parallel_outfile",
+	136:  "enable_phrase_query_sequential_opt",
+	137:  "enable_auto_create_when_overwrite",
 	1000: "disable_file_cache",
 }
 
@@ -4075,16 +4123,16 @@ func (p *TQueryOptions) IsSetSerdeDialect() bool {
 	return p.SerdeDialect != TQueryOptions_SerdeDialect_DEFAULT
 }
 
-func (p *TQueryOptions) IsSetKeepCarriageReturn() bool {
-	return p.KeepCarriageReturn != TQueryOptions_KeepCarriageReturn_DEFAULT
-}
-
 func (p *TQueryOptions) IsSetEnableMatchWithoutInvertedIndex() bool {
 	return p.EnableMatchWithoutInvertedIndex != TQueryOptions_EnableMatchWithoutInvertedIndex_DEFAULT
 }
 
 func (p *TQueryOptions) IsSetEnableFallbackOnMissingInvertedIndex() bool {
 	return p.EnableFallbackOnMissingInvertedIndex != TQueryOptions_EnableFallbackOnMissingInvertedIndex_DEFAULT
+}
+
+func (p *TQueryOptions) IsSetKeepCarriageReturn() bool {
+	return p.KeepCarriageReturn != TQueryOptions_KeepCarriageReturn_DEFAULT
 }
 
 func (p *TQueryOptions) IsSetRuntimeBloomFilterMinSize() bool {
@@ -4137,6 +4185,18 @@ func (p *TQueryOptions) IsSetPartitionTopnMaxPartitions() bool {
 
 func (p *TQueryOptions) IsSetPartitionTopnPrePartitionRows() bool {
 	return p.PartitionTopnPrePartitionRows != TQueryOptions_PartitionTopnPrePartitionRows_DEFAULT
+}
+
+func (p *TQueryOptions) IsSetEnableParallelOutfile() bool {
+	return p.EnableParallelOutfile != TQueryOptions_EnableParallelOutfile_DEFAULT
+}
+
+func (p *TQueryOptions) IsSetEnablePhraseQuerySequentialOpt() bool {
+	return p.EnablePhraseQuerySequentialOpt != TQueryOptions_EnablePhraseQuerySequentialOpt_DEFAULT
+}
+
+func (p *TQueryOptions) IsSetEnableAutoCreateWhenOverwrite() bool {
+	return p.EnableAutoCreateWhenOverwrite != TQueryOptions_EnableAutoCreateWhenOverwrite_DEFAULT
 }
 
 func (p *TQueryOptions) IsSetDisableFileCache() bool {
@@ -5157,6 +5217,30 @@ func (p *TQueryOptions) Read(iprot thrift.TProtocol) (err error) {
 		case 134:
 			if fieldTypeId == thrift.I32 {
 				if err = p.ReadField134(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 135:
+			if fieldTypeId == thrift.BOOL {
+				if err = p.ReadField135(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 136:
+			if fieldTypeId == thrift.BOOL {
+				if err = p.ReadField136(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 137:
+			if fieldTypeId == thrift.BOOL {
+				if err = p.ReadField137(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -6403,7 +6487,7 @@ func (p *TQueryOptions) ReadField119(iprot thrift.TProtocol) error {
 	} else {
 		_field = v
 	}
-	p.KeepCarriageReturn = _field
+	p.EnableMatchWithoutInvertedIndex = _field
 	return nil
 }
 func (p *TQueryOptions) ReadField120(iprot thrift.TProtocol) error {
@@ -6414,7 +6498,7 @@ func (p *TQueryOptions) ReadField120(iprot thrift.TProtocol) error {
 	} else {
 		_field = v
 	}
-	p.EnableMatchWithoutInvertedIndex = _field
+	p.EnableFallbackOnMissingInvertedIndex = _field
 	return nil
 }
 func (p *TQueryOptions) ReadField121(iprot thrift.TProtocol) error {
@@ -6425,7 +6509,7 @@ func (p *TQueryOptions) ReadField121(iprot thrift.TProtocol) error {
 	} else {
 		_field = v
 	}
-	p.EnableFallbackOnMissingInvertedIndex = _field
+	p.KeepCarriageReturn = _field
 	return nil
 }
 func (p *TQueryOptions) ReadField122(iprot thrift.TProtocol) error {
@@ -6569,6 +6653,39 @@ func (p *TQueryOptions) ReadField134(iprot thrift.TProtocol) error {
 		_field = v
 	}
 	p.PartitionTopnPrePartitionRows = _field
+	return nil
+}
+func (p *TQueryOptions) ReadField135(iprot thrift.TProtocol) error {
+
+	var _field bool
+	if v, err := iprot.ReadBool(); err != nil {
+		return err
+	} else {
+		_field = v
+	}
+	p.EnableParallelOutfile = _field
+	return nil
+}
+func (p *TQueryOptions) ReadField136(iprot thrift.TProtocol) error {
+
+	var _field bool
+	if v, err := iprot.ReadBool(); err != nil {
+		return err
+	} else {
+		_field = v
+	}
+	p.EnablePhraseQuerySequentialOpt = _field
+	return nil
+}
+func (p *TQueryOptions) ReadField137(iprot thrift.TProtocol) error {
+
+	var _field bool
+	if v, err := iprot.ReadBool(); err != nil {
+		return err
+	} else {
+		_field = v
+	}
+	p.EnableAutoCreateWhenOverwrite = _field
 	return nil
 }
 func (p *TQueryOptions) ReadField1000(iprot thrift.TProtocol) error {
@@ -7087,6 +7204,18 @@ func (p *TQueryOptions) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField134(oprot); err != nil {
 			fieldId = 134
+			goto WriteFieldError
+		}
+		if err = p.writeField135(oprot); err != nil {
+			fieldId = 135
+			goto WriteFieldError
+		}
+		if err = p.writeField136(oprot); err != nil {
+			fieldId = 136
+			goto WriteFieldError
+		}
+		if err = p.writeField137(oprot); err != nil {
+			fieldId = 137
 			goto WriteFieldError
 		}
 		if err = p.writeField1000(oprot); err != nil {
@@ -9183,11 +9312,11 @@ WriteFieldEndError:
 }
 
 func (p *TQueryOptions) writeField119(oprot thrift.TProtocol) (err error) {
-	if p.IsSetKeepCarriageReturn() {
-		if err = oprot.WriteFieldBegin("keep_carriage_return", thrift.BOOL, 119); err != nil {
+	if p.IsSetEnableMatchWithoutInvertedIndex() {
+		if err = oprot.WriteFieldBegin("enable_match_without_inverted_index", thrift.BOOL, 119); err != nil {
 			goto WriteFieldBeginError
 		}
-		if err := oprot.WriteBool(p.KeepCarriageReturn); err != nil {
+		if err := oprot.WriteBool(p.EnableMatchWithoutInvertedIndex); err != nil {
 			return err
 		}
 		if err = oprot.WriteFieldEnd(); err != nil {
@@ -9202,11 +9331,11 @@ WriteFieldEndError:
 }
 
 func (p *TQueryOptions) writeField120(oprot thrift.TProtocol) (err error) {
-	if p.IsSetEnableMatchWithoutInvertedIndex() {
-		if err = oprot.WriteFieldBegin("enable_match_without_inverted_index", thrift.BOOL, 120); err != nil {
+	if p.IsSetEnableFallbackOnMissingInvertedIndex() {
+		if err = oprot.WriteFieldBegin("enable_fallback_on_missing_inverted_index", thrift.BOOL, 120); err != nil {
 			goto WriteFieldBeginError
 		}
-		if err := oprot.WriteBool(p.EnableMatchWithoutInvertedIndex); err != nil {
+		if err := oprot.WriteBool(p.EnableFallbackOnMissingInvertedIndex); err != nil {
 			return err
 		}
 		if err = oprot.WriteFieldEnd(); err != nil {
@@ -9221,11 +9350,11 @@ WriteFieldEndError:
 }
 
 func (p *TQueryOptions) writeField121(oprot thrift.TProtocol) (err error) {
-	if p.IsSetEnableFallbackOnMissingInvertedIndex() {
-		if err = oprot.WriteFieldBegin("enable_fallback_on_missing_inverted_index", thrift.BOOL, 121); err != nil {
+	if p.IsSetKeepCarriageReturn() {
+		if err = oprot.WriteFieldBegin("keep_carriage_return", thrift.BOOL, 121); err != nil {
 			goto WriteFieldBeginError
 		}
-		if err := oprot.WriteBool(p.EnableFallbackOnMissingInvertedIndex); err != nil {
+		if err := oprot.WriteBool(p.KeepCarriageReturn); err != nil {
 			return err
 		}
 		if err = oprot.WriteFieldEnd(); err != nil {
@@ -9484,6 +9613,63 @@ WriteFieldBeginError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 134 begin error: ", p), err)
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 134 end error: ", p), err)
+}
+
+func (p *TQueryOptions) writeField135(oprot thrift.TProtocol) (err error) {
+	if p.IsSetEnableParallelOutfile() {
+		if err = oprot.WriteFieldBegin("enable_parallel_outfile", thrift.BOOL, 135); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteBool(p.EnableParallelOutfile); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 135 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 135 end error: ", p), err)
+}
+
+func (p *TQueryOptions) writeField136(oprot thrift.TProtocol) (err error) {
+	if p.IsSetEnablePhraseQuerySequentialOpt() {
+		if err = oprot.WriteFieldBegin("enable_phrase_query_sequential_opt", thrift.BOOL, 136); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteBool(p.EnablePhraseQuerySequentialOpt); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 136 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 136 end error: ", p), err)
+}
+
+func (p *TQueryOptions) writeField137(oprot thrift.TProtocol) (err error) {
+	if p.IsSetEnableAutoCreateWhenOverwrite() {
+		if err = oprot.WriteFieldBegin("enable_auto_create_when_overwrite", thrift.BOOL, 137); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteBool(p.EnableAutoCreateWhenOverwrite); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 137 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 137 end error: ", p), err)
 }
 
 func (p *TQueryOptions) writeField1000(oprot thrift.TProtocol) (err error) {
@@ -9846,13 +10032,13 @@ func (p *TQueryOptions) DeepEqual(ano *TQueryOptions) bool {
 	if !p.Field118DeepEqual(ano.SerdeDialect) {
 		return false
 	}
-	if !p.Field119DeepEqual(ano.KeepCarriageReturn) {
+	if !p.Field119DeepEqual(ano.EnableMatchWithoutInvertedIndex) {
 		return false
 	}
-	if !p.Field120DeepEqual(ano.EnableMatchWithoutInvertedIndex) {
+	if !p.Field120DeepEqual(ano.EnableFallbackOnMissingInvertedIndex) {
 		return false
 	}
-	if !p.Field121DeepEqual(ano.EnableFallbackOnMissingInvertedIndex) {
+	if !p.Field121DeepEqual(ano.KeepCarriageReturn) {
 		return false
 	}
 	if !p.Field122DeepEqual(ano.RuntimeBloomFilterMinSize) {
@@ -9892,6 +10078,15 @@ func (p *TQueryOptions) DeepEqual(ano *TQueryOptions) bool {
 		return false
 	}
 	if !p.Field134DeepEqual(ano.PartitionTopnPrePartitionRows) {
+		return false
+	}
+	if !p.Field135DeepEqual(ano.EnableParallelOutfile) {
+		return false
+	}
+	if !p.Field136DeepEqual(ano.EnablePhraseQuerySequentialOpt) {
+		return false
+	}
+	if !p.Field137DeepEqual(ano.EnableAutoCreateWhenOverwrite) {
 		return false
 	}
 	if !p.Field1000DeepEqual(ano.DisableFileCache) {
@@ -10715,21 +10910,21 @@ func (p *TQueryOptions) Field118DeepEqual(src TSerdeDialect) bool {
 }
 func (p *TQueryOptions) Field119DeepEqual(src bool) bool {
 
-	if p.KeepCarriageReturn != src {
+	if p.EnableMatchWithoutInvertedIndex != src {
 		return false
 	}
 	return true
 }
 func (p *TQueryOptions) Field120DeepEqual(src bool) bool {
 
-	if p.EnableMatchWithoutInvertedIndex != src {
+	if p.EnableFallbackOnMissingInvertedIndex != src {
 		return false
 	}
 	return true
 }
 func (p *TQueryOptions) Field121DeepEqual(src bool) bool {
 
-	if p.EnableFallbackOnMissingInvertedIndex != src {
+	if p.KeepCarriageReturn != src {
 		return false
 	}
 	return true
@@ -10821,6 +11016,27 @@ func (p *TQueryOptions) Field133DeepEqual(src int32) bool {
 func (p *TQueryOptions) Field134DeepEqual(src int32) bool {
 
 	if p.PartitionTopnPrePartitionRows != src {
+		return false
+	}
+	return true
+}
+func (p *TQueryOptions) Field135DeepEqual(src bool) bool {
+
+	if p.EnableParallelOutfile != src {
+		return false
+	}
+	return true
+}
+func (p *TQueryOptions) Field136DeepEqual(src bool) bool {
+
+	if p.EnablePhraseQuerySequentialOpt != src {
+		return false
+	}
+	return true
+}
+func (p *TQueryOptions) Field137DeepEqual(src bool) bool {
+
+	if p.EnableAutoCreateWhenOverwrite != src {
 		return false
 	}
 	return true
@@ -11336,6 +11552,7 @@ func (p *TRuntimeFilterTargetParams) Field2DeepEqual(src *types.TNetworkAddress)
 type TRuntimeFilterTargetParamsV2 struct {
 	TargetFragmentInstanceIds  []*types.TUniqueId     `thrift:"target_fragment_instance_ids,1,required" frugal:"1,required,list<types.TUniqueId>" json:"target_fragment_instance_ids"`
 	TargetFragmentInstanceAddr *types.TNetworkAddress `thrift:"target_fragment_instance_addr,2,required" frugal:"2,required,types.TNetworkAddress" json:"target_fragment_instance_addr"`
+	TargetFragmentIds          []int32                `thrift:"target_fragment_ids,3,optional" frugal:"3,optional,list<i32>" json:"target_fragment_ids,omitempty"`
 }
 
 func NewTRuntimeFilterTargetParamsV2() *TRuntimeFilterTargetParamsV2 {
@@ -11357,20 +11574,37 @@ func (p *TRuntimeFilterTargetParamsV2) GetTargetFragmentInstanceAddr() (v *types
 	}
 	return p.TargetFragmentInstanceAddr
 }
+
+var TRuntimeFilterTargetParamsV2_TargetFragmentIds_DEFAULT []int32
+
+func (p *TRuntimeFilterTargetParamsV2) GetTargetFragmentIds() (v []int32) {
+	if !p.IsSetTargetFragmentIds() {
+		return TRuntimeFilterTargetParamsV2_TargetFragmentIds_DEFAULT
+	}
+	return p.TargetFragmentIds
+}
 func (p *TRuntimeFilterTargetParamsV2) SetTargetFragmentInstanceIds(val []*types.TUniqueId) {
 	p.TargetFragmentInstanceIds = val
 }
 func (p *TRuntimeFilterTargetParamsV2) SetTargetFragmentInstanceAddr(val *types.TNetworkAddress) {
 	p.TargetFragmentInstanceAddr = val
 }
+func (p *TRuntimeFilterTargetParamsV2) SetTargetFragmentIds(val []int32) {
+	p.TargetFragmentIds = val
+}
 
 var fieldIDToName_TRuntimeFilterTargetParamsV2 = map[int16]string{
 	1: "target_fragment_instance_ids",
 	2: "target_fragment_instance_addr",
+	3: "target_fragment_ids",
 }
 
 func (p *TRuntimeFilterTargetParamsV2) IsSetTargetFragmentInstanceAddr() bool {
 	return p.TargetFragmentInstanceAddr != nil
+}
+
+func (p *TRuntimeFilterTargetParamsV2) IsSetTargetFragmentIds() bool {
+	return p.TargetFragmentIds != nil
 }
 
 func (p *TRuntimeFilterTargetParamsV2) Read(iprot thrift.TProtocol) (err error) {
@@ -11409,6 +11643,14 @@ func (p *TRuntimeFilterTargetParamsV2) Read(iprot thrift.TProtocol) (err error) 
 					goto ReadFieldError
 				}
 				issetTargetFragmentInstanceAddr = true
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 3:
+			if fieldTypeId == thrift.LIST {
+				if err = p.ReadField3(iprot); err != nil {
+					goto ReadFieldError
+				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
 				goto SkipFieldError
 			}
@@ -11483,6 +11725,29 @@ func (p *TRuntimeFilterTargetParamsV2) ReadField2(iprot thrift.TProtocol) error 
 	p.TargetFragmentInstanceAddr = _field
 	return nil
 }
+func (p *TRuntimeFilterTargetParamsV2) ReadField3(iprot thrift.TProtocol) error {
+	_, size, err := iprot.ReadListBegin()
+	if err != nil {
+		return err
+	}
+	_field := make([]int32, 0, size)
+	for i := 0; i < size; i++ {
+
+		var _elem int32
+		if v, err := iprot.ReadI32(); err != nil {
+			return err
+		} else {
+			_elem = v
+		}
+
+		_field = append(_field, _elem)
+	}
+	if err := iprot.ReadListEnd(); err != nil {
+		return err
+	}
+	p.TargetFragmentIds = _field
+	return nil
+}
 
 func (p *TRuntimeFilterTargetParamsV2) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -11496,6 +11761,10 @@ func (p *TRuntimeFilterTargetParamsV2) Write(oprot thrift.TProtocol) (err error)
 		}
 		if err = p.writeField2(oprot); err != nil {
 			fieldId = 2
+			goto WriteFieldError
+		}
+		if err = p.writeField3(oprot); err != nil {
+			fieldId = 3
 			goto WriteFieldError
 		}
 	}
@@ -11558,6 +11827,33 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 2 end error: ", p), err)
 }
 
+func (p *TRuntimeFilterTargetParamsV2) writeField3(oprot thrift.TProtocol) (err error) {
+	if p.IsSetTargetFragmentIds() {
+		if err = oprot.WriteFieldBegin("target_fragment_ids", thrift.LIST, 3); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteListBegin(thrift.I32, len(p.TargetFragmentIds)); err != nil {
+			return err
+		}
+		for _, v := range p.TargetFragmentIds {
+			if err := oprot.WriteI32(v); err != nil {
+				return err
+			}
+		}
+		if err := oprot.WriteListEnd(); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 end error: ", p), err)
+}
+
 func (p *TRuntimeFilterTargetParamsV2) String() string {
 	if p == nil {
 		return "<nil>"
@@ -11576,6 +11872,9 @@ func (p *TRuntimeFilterTargetParamsV2) DeepEqual(ano *TRuntimeFilterTargetParams
 		return false
 	}
 	if !p.Field2DeepEqual(ano.TargetFragmentInstanceAddr) {
+		return false
+	}
+	if !p.Field3DeepEqual(ano.TargetFragmentIds) {
 		return false
 	}
 	return true
@@ -11598,6 +11897,19 @@ func (p *TRuntimeFilterTargetParamsV2) Field2DeepEqual(src *types.TNetworkAddres
 
 	if !p.TargetFragmentInstanceAddr.DeepEqual(src) {
 		return false
+	}
+	return true
+}
+func (p *TRuntimeFilterTargetParamsV2) Field3DeepEqual(src []int32) bool {
+
+	if len(p.TargetFragmentIds) != len(src) {
+		return false
+	}
+	for i, v := range p.TargetFragmentIds {
+		_src := src[i]
+		if v != _src {
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/rpc/kitex_gen/palointernalservice/k-PaloInternalService.go
+++ b/pkg/rpc/kitex_gen/palointernalservice/k-PaloInternalService.go
@@ -2887,6 +2887,48 @@ func (p *TQueryOptions) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 135:
+			if fieldTypeId == thrift.BOOL {
+				l, err = p.FastReadField135(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 136:
+			if fieldTypeId == thrift.BOOL {
+				l, err = p.FastReadField136(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 137:
+			if fieldTypeId == thrift.BOOL {
+				l, err = p.FastReadField137(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		case 1000:
 			if fieldTypeId == thrift.BOOL {
 				l, err = p.FastReadField1000(buf[offset:])
@@ -4459,7 +4501,7 @@ func (p *TQueryOptions) FastReadField119(buf []byte) (int, error) {
 	} else {
 		offset += l
 
-		p.KeepCarriageReturn = v
+		p.EnableMatchWithoutInvertedIndex = v
 
 	}
 	return offset, nil
@@ -4473,7 +4515,7 @@ func (p *TQueryOptions) FastReadField120(buf []byte) (int, error) {
 	} else {
 		offset += l
 
-		p.EnableMatchWithoutInvertedIndex = v
+		p.EnableFallbackOnMissingInvertedIndex = v
 
 	}
 	return offset, nil
@@ -4487,7 +4529,7 @@ func (p *TQueryOptions) FastReadField121(buf []byte) (int, error) {
 	} else {
 		offset += l
 
-		p.EnableFallbackOnMissingInvertedIndex = v
+		p.KeepCarriageReturn = v
 
 	}
 	return offset, nil
@@ -4675,6 +4717,48 @@ func (p *TQueryOptions) FastReadField134(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TQueryOptions) FastReadField135(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadBool(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+
+		p.EnableParallelOutfile = v
+
+	}
+	return offset, nil
+}
+
+func (p *TQueryOptions) FastReadField136(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadBool(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+
+		p.EnablePhraseQuerySequentialOpt = v
+
+	}
+	return offset, nil
+}
+
+func (p *TQueryOptions) FastReadField137(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadBool(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+
+		p.EnableAutoCreateWhenOverwrite = v
+
+	}
+	return offset, nil
+}
+
 func (p *TQueryOptions) FastReadField1000(buf []byte) (int, error) {
 	offset := 0
 
@@ -4818,6 +4902,9 @@ func (p *TQueryOptions) FastWriteNocopy(buf []byte, binaryWriter bthrift.BinaryW
 		offset += p.fastWriteField132(buf[offset:], binaryWriter)
 		offset += p.fastWriteField133(buf[offset:], binaryWriter)
 		offset += p.fastWriteField134(buf[offset:], binaryWriter)
+		offset += p.fastWriteField135(buf[offset:], binaryWriter)
+		offset += p.fastWriteField136(buf[offset:], binaryWriter)
+		offset += p.fastWriteField137(buf[offset:], binaryWriter)
 		offset += p.fastWriteField1000(buf[offset:], binaryWriter)
 		offset += p.fastWriteField18(buf[offset:], binaryWriter)
 		offset += p.fastWriteField42(buf[offset:], binaryWriter)
@@ -4959,6 +5046,9 @@ func (p *TQueryOptions) BLength() int {
 		l += p.field132Length()
 		l += p.field133Length()
 		l += p.field134Length()
+		l += p.field135Length()
+		l += p.field136Length()
+		l += p.field137Length()
 		l += p.field1000Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
@@ -6166,9 +6256,9 @@ func (p *TQueryOptions) fastWriteField118(buf []byte, binaryWriter bthrift.Binar
 
 func (p *TQueryOptions) fastWriteField119(buf []byte, binaryWriter bthrift.BinaryWriter) int {
 	offset := 0
-	if p.IsSetKeepCarriageReturn() {
-		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "keep_carriage_return", thrift.BOOL, 119)
-		offset += bthrift.Binary.WriteBool(buf[offset:], p.KeepCarriageReturn)
+	if p.IsSetEnableMatchWithoutInvertedIndex() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "enable_match_without_inverted_index", thrift.BOOL, 119)
+		offset += bthrift.Binary.WriteBool(buf[offset:], p.EnableMatchWithoutInvertedIndex)
 
 		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
 	}
@@ -6177,9 +6267,9 @@ func (p *TQueryOptions) fastWriteField119(buf []byte, binaryWriter bthrift.Binar
 
 func (p *TQueryOptions) fastWriteField120(buf []byte, binaryWriter bthrift.BinaryWriter) int {
 	offset := 0
-	if p.IsSetEnableMatchWithoutInvertedIndex() {
-		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "enable_match_without_inverted_index", thrift.BOOL, 120)
-		offset += bthrift.Binary.WriteBool(buf[offset:], p.EnableMatchWithoutInvertedIndex)
+	if p.IsSetEnableFallbackOnMissingInvertedIndex() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "enable_fallback_on_missing_inverted_index", thrift.BOOL, 120)
+		offset += bthrift.Binary.WriteBool(buf[offset:], p.EnableFallbackOnMissingInvertedIndex)
 
 		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
 	}
@@ -6188,9 +6278,9 @@ func (p *TQueryOptions) fastWriteField120(buf []byte, binaryWriter bthrift.Binar
 
 func (p *TQueryOptions) fastWriteField121(buf []byte, binaryWriter bthrift.BinaryWriter) int {
 	offset := 0
-	if p.IsSetEnableFallbackOnMissingInvertedIndex() {
-		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "enable_fallback_on_missing_inverted_index", thrift.BOOL, 121)
-		offset += bthrift.Binary.WriteBool(buf[offset:], p.EnableFallbackOnMissingInvertedIndex)
+	if p.IsSetKeepCarriageReturn() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "keep_carriage_return", thrift.BOOL, 121)
+		offset += bthrift.Binary.WriteBool(buf[offset:], p.KeepCarriageReturn)
 
 		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
 	}
@@ -6334,6 +6424,39 @@ func (p *TQueryOptions) fastWriteField134(buf []byte, binaryWriter bthrift.Binar
 	if p.IsSetPartitionTopnPrePartitionRows() {
 		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "partition_topn_pre_partition_rows", thrift.I32, 134)
 		offset += bthrift.Binary.WriteI32(buf[offset:], p.PartitionTopnPrePartitionRows)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TQueryOptions) fastWriteField135(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetEnableParallelOutfile() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "enable_parallel_outfile", thrift.BOOL, 135)
+		offset += bthrift.Binary.WriteBool(buf[offset:], p.EnableParallelOutfile)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TQueryOptions) fastWriteField136(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetEnablePhraseQuerySequentialOpt() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "enable_phrase_query_sequential_opt", thrift.BOOL, 136)
+		offset += bthrift.Binary.WriteBool(buf[offset:], p.EnablePhraseQuerySequentialOpt)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TQueryOptions) fastWriteField137(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetEnableAutoCreateWhenOverwrite() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "enable_auto_create_when_overwrite", thrift.BOOL, 137)
+		offset += bthrift.Binary.WriteBool(buf[offset:], p.EnableAutoCreateWhenOverwrite)
 
 		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
 	}
@@ -7551,9 +7674,9 @@ func (p *TQueryOptions) field118Length() int {
 
 func (p *TQueryOptions) field119Length() int {
 	l := 0
-	if p.IsSetKeepCarriageReturn() {
-		l += bthrift.Binary.FieldBeginLength("keep_carriage_return", thrift.BOOL, 119)
-		l += bthrift.Binary.BoolLength(p.KeepCarriageReturn)
+	if p.IsSetEnableMatchWithoutInvertedIndex() {
+		l += bthrift.Binary.FieldBeginLength("enable_match_without_inverted_index", thrift.BOOL, 119)
+		l += bthrift.Binary.BoolLength(p.EnableMatchWithoutInvertedIndex)
 
 		l += bthrift.Binary.FieldEndLength()
 	}
@@ -7562,9 +7685,9 @@ func (p *TQueryOptions) field119Length() int {
 
 func (p *TQueryOptions) field120Length() int {
 	l := 0
-	if p.IsSetEnableMatchWithoutInvertedIndex() {
-		l += bthrift.Binary.FieldBeginLength("enable_match_without_inverted_index", thrift.BOOL, 120)
-		l += bthrift.Binary.BoolLength(p.EnableMatchWithoutInvertedIndex)
+	if p.IsSetEnableFallbackOnMissingInvertedIndex() {
+		l += bthrift.Binary.FieldBeginLength("enable_fallback_on_missing_inverted_index", thrift.BOOL, 120)
+		l += bthrift.Binary.BoolLength(p.EnableFallbackOnMissingInvertedIndex)
 
 		l += bthrift.Binary.FieldEndLength()
 	}
@@ -7573,9 +7696,9 @@ func (p *TQueryOptions) field120Length() int {
 
 func (p *TQueryOptions) field121Length() int {
 	l := 0
-	if p.IsSetEnableFallbackOnMissingInvertedIndex() {
-		l += bthrift.Binary.FieldBeginLength("enable_fallback_on_missing_inverted_index", thrift.BOOL, 121)
-		l += bthrift.Binary.BoolLength(p.EnableFallbackOnMissingInvertedIndex)
+	if p.IsSetKeepCarriageReturn() {
+		l += bthrift.Binary.FieldBeginLength("keep_carriage_return", thrift.BOOL, 121)
+		l += bthrift.Binary.BoolLength(p.KeepCarriageReturn)
 
 		l += bthrift.Binary.FieldEndLength()
 	}
@@ -7719,6 +7842,39 @@ func (p *TQueryOptions) field134Length() int {
 	if p.IsSetPartitionTopnPrePartitionRows() {
 		l += bthrift.Binary.FieldBeginLength("partition_topn_pre_partition_rows", thrift.I32, 134)
 		l += bthrift.Binary.I32Length(p.PartitionTopnPrePartitionRows)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TQueryOptions) field135Length() int {
+	l := 0
+	if p.IsSetEnableParallelOutfile() {
+		l += bthrift.Binary.FieldBeginLength("enable_parallel_outfile", thrift.BOOL, 135)
+		l += bthrift.Binary.BoolLength(p.EnableParallelOutfile)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TQueryOptions) field136Length() int {
+	l := 0
+	if p.IsSetEnablePhraseQuerySequentialOpt() {
+		l += bthrift.Binary.FieldBeginLength("enable_phrase_query_sequential_opt", thrift.BOOL, 136)
+		l += bthrift.Binary.BoolLength(p.EnablePhraseQuerySequentialOpt)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TQueryOptions) field137Length() int {
+	l := 0
+	if p.IsSetEnableAutoCreateWhenOverwrite() {
+		l += bthrift.Binary.FieldBeginLength("enable_auto_create_when_overwrite", thrift.BOOL, 137)
+		l += bthrift.Binary.BoolLength(p.EnableAutoCreateWhenOverwrite)
 
 		l += bthrift.Binary.FieldEndLength()
 	}
@@ -8164,6 +8320,20 @@ func (p *TRuntimeFilterTargetParamsV2) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 3:
+			if fieldTypeId == thrift.LIST {
+				l, err = p.FastReadField3(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -8250,6 +8420,36 @@ func (p *TRuntimeFilterTargetParamsV2) FastReadField2(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TRuntimeFilterTargetParamsV2) FastReadField3(buf []byte) (int, error) {
+	offset := 0
+
+	_, size, l, err := bthrift.Binary.ReadListBegin(buf[offset:])
+	offset += l
+	if err != nil {
+		return offset, err
+	}
+	p.TargetFragmentIds = make([]int32, 0, size)
+	for i := 0; i < size; i++ {
+		var _elem int32
+		if v, l, err := bthrift.Binary.ReadI32(buf[offset:]); err != nil {
+			return offset, err
+		} else {
+			offset += l
+
+			_elem = v
+
+		}
+
+		p.TargetFragmentIds = append(p.TargetFragmentIds, _elem)
+	}
+	if l, err := bthrift.Binary.ReadListEnd(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TRuntimeFilterTargetParamsV2) FastWrite(buf []byte) int {
 	return 0
@@ -8261,6 +8461,7 @@ func (p *TRuntimeFilterTargetParamsV2) FastWriteNocopy(buf []byte, binaryWriter 
 	if p != nil {
 		offset += p.fastWriteField1(buf[offset:], binaryWriter)
 		offset += p.fastWriteField2(buf[offset:], binaryWriter)
+		offset += p.fastWriteField3(buf[offset:], binaryWriter)
 	}
 	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
 	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
@@ -8273,6 +8474,7 @@ func (p *TRuntimeFilterTargetParamsV2) BLength() int {
 	if p != nil {
 		l += p.field1Length()
 		l += p.field2Length()
+		l += p.field3Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -8303,6 +8505,25 @@ func (p *TRuntimeFilterTargetParamsV2) fastWriteField2(buf []byte, binaryWriter 
 	return offset
 }
 
+func (p *TRuntimeFilterTargetParamsV2) fastWriteField3(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetTargetFragmentIds() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "target_fragment_ids", thrift.LIST, 3)
+		listBeginOffset := offset
+		offset += bthrift.Binary.ListBeginLength(thrift.I32, 0)
+		var length int
+		for _, v := range p.TargetFragmentIds {
+			length++
+			offset += bthrift.Binary.WriteI32(buf[offset:], v)
+
+		}
+		bthrift.Binary.WriteListBegin(buf[listBeginOffset:], thrift.I32, length)
+		offset += bthrift.Binary.WriteListEnd(buf[offset:])
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TRuntimeFilterTargetParamsV2) field1Length() int {
 	l := 0
 	l += bthrift.Binary.FieldBeginLength("target_fragment_instance_ids", thrift.LIST, 1)
@@ -8320,6 +8541,19 @@ func (p *TRuntimeFilterTargetParamsV2) field2Length() int {
 	l += bthrift.Binary.FieldBeginLength("target_fragment_instance_addr", thrift.STRUCT, 2)
 	l += p.TargetFragmentInstanceAddr.BLength()
 	l += bthrift.Binary.FieldEndLength()
+	return l
+}
+
+func (p *TRuntimeFilterTargetParamsV2) field3Length() int {
+	l := 0
+	if p.IsSetTargetFragmentIds() {
+		l += bthrift.Binary.FieldBeginLength("target_fragment_ids", thrift.LIST, 3)
+		l += bthrift.Binary.ListBeginLength(thrift.I32, len(p.TargetFragmentIds))
+		var tmpV int32
+		l += bthrift.Binary.I32Length(int32(tmpV)) * len(p.TargetFragmentIds)
+		l += bthrift.Binary.ListEndLength()
+		l += bthrift.Binary.FieldEndLength()
+	}
 	return l
 }
 

--- a/pkg/rpc/kitex_gen/plannodes/PlanNodes.go
+++ b/pkg/rpc/kitex_gen/plannodes/PlanNodes.go
@@ -6956,6 +6956,7 @@ type TFileTextScanRangeParams struct {
 	MapkvDelimiter      *string `thrift:"mapkv_delimiter,4,optional" frugal:"4,optional,string" json:"mapkv_delimiter,omitempty"`
 	Enclose             *int8   `thrift:"enclose,5,optional" frugal:"5,optional,i8" json:"enclose,omitempty"`
 	Escape              *int8   `thrift:"escape,6,optional" frugal:"6,optional,i8" json:"escape,omitempty"`
+	NullFormat          *string `thrift:"null_format,7,optional" frugal:"7,optional,string" json:"null_format,omitempty"`
 }
 
 func NewTFileTextScanRangeParams() *TFileTextScanRangeParams {
@@ -7018,6 +7019,15 @@ func (p *TFileTextScanRangeParams) GetEscape() (v int8) {
 	}
 	return *p.Escape
 }
+
+var TFileTextScanRangeParams_NullFormat_DEFAULT string
+
+func (p *TFileTextScanRangeParams) GetNullFormat() (v string) {
+	if !p.IsSetNullFormat() {
+		return TFileTextScanRangeParams_NullFormat_DEFAULT
+	}
+	return *p.NullFormat
+}
 func (p *TFileTextScanRangeParams) SetColumnSeparator(val *string) {
 	p.ColumnSeparator = val
 }
@@ -7036,6 +7046,9 @@ func (p *TFileTextScanRangeParams) SetEnclose(val *int8) {
 func (p *TFileTextScanRangeParams) SetEscape(val *int8) {
 	p.Escape = val
 }
+func (p *TFileTextScanRangeParams) SetNullFormat(val *string) {
+	p.NullFormat = val
+}
 
 var fieldIDToName_TFileTextScanRangeParams = map[int16]string{
 	1: "column_separator",
@@ -7044,6 +7057,7 @@ var fieldIDToName_TFileTextScanRangeParams = map[int16]string{
 	4: "mapkv_delimiter",
 	5: "enclose",
 	6: "escape",
+	7: "null_format",
 }
 
 func (p *TFileTextScanRangeParams) IsSetColumnSeparator() bool {
@@ -7068,6 +7082,10 @@ func (p *TFileTextScanRangeParams) IsSetEnclose() bool {
 
 func (p *TFileTextScanRangeParams) IsSetEscape() bool {
 	return p.Escape != nil
+}
+
+func (p *TFileTextScanRangeParams) IsSetNullFormat() bool {
+	return p.NullFormat != nil
 }
 
 func (p *TFileTextScanRangeParams) Read(iprot thrift.TProtocol) (err error) {
@@ -7132,6 +7150,14 @@ func (p *TFileTextScanRangeParams) Read(iprot thrift.TProtocol) (err error) {
 		case 6:
 			if fieldTypeId == thrift.BYTE {
 				if err = p.ReadField6(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 7:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField7(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -7232,6 +7258,17 @@ func (p *TFileTextScanRangeParams) ReadField6(iprot thrift.TProtocol) error {
 	p.Escape = _field
 	return nil
 }
+func (p *TFileTextScanRangeParams) ReadField7(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.NullFormat = _field
+	return nil
+}
 
 func (p *TFileTextScanRangeParams) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -7261,6 +7298,10 @@ func (p *TFileTextScanRangeParams) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField6(oprot); err != nil {
 			fieldId = 6
+			goto WriteFieldError
+		}
+		if err = p.writeField7(oprot); err != nil {
+			fieldId = 7
 			goto WriteFieldError
 		}
 	}
@@ -7395,6 +7436,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 6 end error: ", p), err)
 }
 
+func (p *TFileTextScanRangeParams) writeField7(oprot thrift.TProtocol) (err error) {
+	if p.IsSetNullFormat() {
+		if err = oprot.WriteFieldBegin("null_format", thrift.STRING, 7); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.NullFormat); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 7 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 7 end error: ", p), err)
+}
+
 func (p *TFileTextScanRangeParams) String() string {
 	if p == nil {
 		return "<nil>"
@@ -7425,6 +7485,9 @@ func (p *TFileTextScanRangeParams) DeepEqual(ano *TFileTextScanRangeParams) bool
 		return false
 	}
 	if !p.Field6DeepEqual(ano.Escape) {
+		return false
+	}
+	if !p.Field7DeepEqual(ano.NullFormat) {
 		return false
 	}
 	return true
@@ -7498,6 +7561,18 @@ func (p *TFileTextScanRangeParams) Field6DeepEqual(src *int8) bool {
 		return false
 	}
 	if *p.Escape != *src {
+		return false
+	}
+	return true
+}
+func (p *TFileTextScanRangeParams) Field7DeepEqual(src *string) bool {
+
+	if p.NullFormat == src {
+		return true
+	} else if p.NullFormat == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.NullFormat, *src) != 0 {
 		return false
 	}
 	return true
@@ -9260,6 +9335,7 @@ type TIcebergFileDesc struct {
 	DeleteTableTupleId *types.TTupleId           `thrift:"delete_table_tuple_id,4,optional" frugal:"4,optional,i32" json:"delete_table_tuple_id,omitempty"`
 	FileSelectConjunct *exprs.TExpr              `thrift:"file_select_conjunct,5,optional" frugal:"5,optional,exprs.TExpr" json:"file_select_conjunct,omitempty"`
 	OriginalFilePath   *string                   `thrift:"original_file_path,6,optional" frugal:"6,optional,string" json:"original_file_path,omitempty"`
+	RowCount           *int64                    `thrift:"row_count,7,optional" frugal:"7,optional,i64" json:"row_count,omitempty"`
 }
 
 func NewTIcebergFileDesc() *TIcebergFileDesc {
@@ -9322,6 +9398,15 @@ func (p *TIcebergFileDesc) GetOriginalFilePath() (v string) {
 	}
 	return *p.OriginalFilePath
 }
+
+var TIcebergFileDesc_RowCount_DEFAULT int64
+
+func (p *TIcebergFileDesc) GetRowCount() (v int64) {
+	if !p.IsSetRowCount() {
+		return TIcebergFileDesc_RowCount_DEFAULT
+	}
+	return *p.RowCount
+}
 func (p *TIcebergFileDesc) SetFormatVersion(val *int32) {
 	p.FormatVersion = val
 }
@@ -9340,6 +9425,9 @@ func (p *TIcebergFileDesc) SetFileSelectConjunct(val *exprs.TExpr) {
 func (p *TIcebergFileDesc) SetOriginalFilePath(val *string) {
 	p.OriginalFilePath = val
 }
+func (p *TIcebergFileDesc) SetRowCount(val *int64) {
+	p.RowCount = val
+}
 
 var fieldIDToName_TIcebergFileDesc = map[int16]string{
 	1: "format_version",
@@ -9348,6 +9436,7 @@ var fieldIDToName_TIcebergFileDesc = map[int16]string{
 	4: "delete_table_tuple_id",
 	5: "file_select_conjunct",
 	6: "original_file_path",
+	7: "row_count",
 }
 
 func (p *TIcebergFileDesc) IsSetFormatVersion() bool {
@@ -9372,6 +9461,10 @@ func (p *TIcebergFileDesc) IsSetFileSelectConjunct() bool {
 
 func (p *TIcebergFileDesc) IsSetOriginalFilePath() bool {
 	return p.OriginalFilePath != nil
+}
+
+func (p *TIcebergFileDesc) IsSetRowCount() bool {
+	return p.RowCount != nil
 }
 
 func (p *TIcebergFileDesc) Read(iprot thrift.TProtocol) (err error) {
@@ -9436,6 +9529,14 @@ func (p *TIcebergFileDesc) Read(iprot thrift.TProtocol) (err error) {
 		case 6:
 			if fieldTypeId == thrift.STRING {
 				if err = p.ReadField6(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 7:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField7(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -9545,6 +9646,17 @@ func (p *TIcebergFileDesc) ReadField6(iprot thrift.TProtocol) error {
 	p.OriginalFilePath = _field
 	return nil
 }
+func (p *TIcebergFileDesc) ReadField7(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.RowCount = _field
+	return nil
+}
 
 func (p *TIcebergFileDesc) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -9574,6 +9686,10 @@ func (p *TIcebergFileDesc) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField6(oprot); err != nil {
 			fieldId = 6
+			goto WriteFieldError
+		}
+		if err = p.writeField7(oprot); err != nil {
+			fieldId = 7
 			goto WriteFieldError
 		}
 	}
@@ -9716,6 +9832,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 6 end error: ", p), err)
 }
 
+func (p *TIcebergFileDesc) writeField7(oprot thrift.TProtocol) (err error) {
+	if p.IsSetRowCount() {
+		if err = oprot.WriteFieldBegin("row_count", thrift.I64, 7); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.RowCount); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 7 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 7 end error: ", p), err)
+}
+
 func (p *TIcebergFileDesc) String() string {
 	if p == nil {
 		return "<nil>"
@@ -9746,6 +9881,9 @@ func (p *TIcebergFileDesc) DeepEqual(ano *TIcebergFileDesc) bool {
 		return false
 	}
 	if !p.Field6DeepEqual(ano.OriginalFilePath) {
+		return false
+	}
+	if !p.Field7DeepEqual(ano.RowCount) {
 		return false
 	}
 	return true
@@ -9815,6 +9953,18 @@ func (p *TIcebergFileDesc) Field6DeepEqual(src *string) bool {
 		return false
 	}
 	if strings.Compare(*p.OriginalFilePath, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TIcebergFileDesc) Field7DeepEqual(src *int64) bool {
+
+	if p.RowCount == src {
+		return true
+	} else if p.RowCount == nil || src == nil {
+		return false
+	}
+	if *p.RowCount != *src {
 		return false
 	}
 	return true
@@ -15269,6 +15419,7 @@ type TFileScanRangeParams struct {
 	PreFilterExprsList          []*exprs.TExpr                  `thrift:"pre_filter_exprs_list,20,optional" frugal:"20,optional,list<exprs.TExpr>" json:"pre_filter_exprs_list,omitempty"`
 	LoadId                      *types.TUniqueId                `thrift:"load_id,21,optional" frugal:"21,optional,types.TUniqueId" json:"load_id,omitempty"`
 	TextSerdeType               *TTextSerdeType                 `thrift:"text_serde_type,22,optional" frugal:"22,optional,TTextSerdeType" json:"text_serde_type,omitempty"`
+	SequenceMapCol              *string                         `thrift:"sequence_map_col,23,optional" frugal:"23,optional,string" json:"sequence_map_col,omitempty"`
 }
 
 func NewTFileScanRangeParams() *TFileScanRangeParams {
@@ -15475,6 +15626,15 @@ func (p *TFileScanRangeParams) GetTextSerdeType() (v TTextSerdeType) {
 	}
 	return *p.TextSerdeType
 }
+
+var TFileScanRangeParams_SequenceMapCol_DEFAULT string
+
+func (p *TFileScanRangeParams) GetSequenceMapCol() (v string) {
+	if !p.IsSetSequenceMapCol() {
+		return TFileScanRangeParams_SequenceMapCol_DEFAULT
+	}
+	return *p.SequenceMapCol
+}
 func (p *TFileScanRangeParams) SetFileType(val *types.TFileType) {
 	p.FileType = val
 }
@@ -15541,6 +15701,9 @@ func (p *TFileScanRangeParams) SetLoadId(val *types.TUniqueId) {
 func (p *TFileScanRangeParams) SetTextSerdeType(val *TTextSerdeType) {
 	p.TextSerdeType = val
 }
+func (p *TFileScanRangeParams) SetSequenceMapCol(val *string) {
+	p.SequenceMapCol = val
+}
 
 var fieldIDToName_TFileScanRangeParams = map[int16]string{
 	1:  "file_type",
@@ -15565,6 +15728,7 @@ var fieldIDToName_TFileScanRangeParams = map[int16]string{
 	20: "pre_filter_exprs_list",
 	21: "load_id",
 	22: "text_serde_type",
+	23: "sequence_map_col",
 }
 
 func (p *TFileScanRangeParams) IsSetFileType() bool {
@@ -15653,6 +15817,10 @@ func (p *TFileScanRangeParams) IsSetLoadId() bool {
 
 func (p *TFileScanRangeParams) IsSetTextSerdeType() bool {
 	return p.TextSerdeType != nil
+}
+
+func (p *TFileScanRangeParams) IsSetSequenceMapCol() bool {
+	return p.SequenceMapCol != nil
 }
 
 func (p *TFileScanRangeParams) Read(iprot thrift.TProtocol) (err error) {
@@ -15845,6 +16013,14 @@ func (p *TFileScanRangeParams) Read(iprot thrift.TProtocol) (err error) {
 		case 22:
 			if fieldTypeId == thrift.I32 {
 				if err = p.ReadField22(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 23:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField23(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -16248,6 +16424,17 @@ func (p *TFileScanRangeParams) ReadField22(iprot thrift.TProtocol) error {
 	p.TextSerdeType = _field
 	return nil
 }
+func (p *TFileScanRangeParams) ReadField23(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.SequenceMapCol = _field
+	return nil
+}
 
 func (p *TFileScanRangeParams) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -16341,6 +16528,10 @@ func (p *TFileScanRangeParams) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField22(oprot); err != nil {
 			fieldId = 22
+			goto WriteFieldError
+		}
+		if err = p.writeField23(oprot); err != nil {
+			fieldId = 23
 			goto WriteFieldError
 		}
 	}
@@ -16866,6 +17057,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 22 end error: ", p), err)
 }
 
+func (p *TFileScanRangeParams) writeField23(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSequenceMapCol() {
+		if err = oprot.WriteFieldBegin("sequence_map_col", thrift.STRING, 23); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.SequenceMapCol); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 23 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 23 end error: ", p), err)
+}
+
 func (p *TFileScanRangeParams) String() string {
 	if p == nil {
 		return "<nil>"
@@ -16944,6 +17154,9 @@ func (p *TFileScanRangeParams) DeepEqual(ano *TFileScanRangeParams) bool {
 		return false
 	}
 	if !p.Field22DeepEqual(ano.TextSerdeType) {
+		return false
+	}
+	if !p.Field23DeepEqual(ano.SequenceMapCol) {
 		return false
 	}
 	return true
@@ -17193,6 +17406,18 @@ func (p *TFileScanRangeParams) Field22DeepEqual(src *TTextSerdeType) bool {
 		return false
 	}
 	if *p.TextSerdeType != *src {
+		return false
+	}
+	return true
+}
+func (p *TFileScanRangeParams) Field23DeepEqual(src *string) bool {
+
+	if p.SequenceMapCol == src {
+		return true
+	} else if p.SequenceMapCol == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.SequenceMapCol, *src) != 0 {
 		return false
 	}
 	return true
@@ -20826,6 +21051,335 @@ func (p *TPartitionsMetadataParams) Field3DeepEqual(src *string) bool {
 	return true
 }
 
+type TPartitionValuesMetadataParams struct {
+	Catalog  *string `thrift:"catalog,1,optional" frugal:"1,optional,string" json:"catalog,omitempty"`
+	Database *string `thrift:"database,2,optional" frugal:"2,optional,string" json:"database,omitempty"`
+	Table    *string `thrift:"table,3,optional" frugal:"3,optional,string" json:"table,omitempty"`
+}
+
+func NewTPartitionValuesMetadataParams() *TPartitionValuesMetadataParams {
+	return &TPartitionValuesMetadataParams{}
+}
+
+func (p *TPartitionValuesMetadataParams) InitDefault() {
+}
+
+var TPartitionValuesMetadataParams_Catalog_DEFAULT string
+
+func (p *TPartitionValuesMetadataParams) GetCatalog() (v string) {
+	if !p.IsSetCatalog() {
+		return TPartitionValuesMetadataParams_Catalog_DEFAULT
+	}
+	return *p.Catalog
+}
+
+var TPartitionValuesMetadataParams_Database_DEFAULT string
+
+func (p *TPartitionValuesMetadataParams) GetDatabase() (v string) {
+	if !p.IsSetDatabase() {
+		return TPartitionValuesMetadataParams_Database_DEFAULT
+	}
+	return *p.Database
+}
+
+var TPartitionValuesMetadataParams_Table_DEFAULT string
+
+func (p *TPartitionValuesMetadataParams) GetTable() (v string) {
+	if !p.IsSetTable() {
+		return TPartitionValuesMetadataParams_Table_DEFAULT
+	}
+	return *p.Table
+}
+func (p *TPartitionValuesMetadataParams) SetCatalog(val *string) {
+	p.Catalog = val
+}
+func (p *TPartitionValuesMetadataParams) SetDatabase(val *string) {
+	p.Database = val
+}
+func (p *TPartitionValuesMetadataParams) SetTable(val *string) {
+	p.Table = val
+}
+
+var fieldIDToName_TPartitionValuesMetadataParams = map[int16]string{
+	1: "catalog",
+	2: "database",
+	3: "table",
+}
+
+func (p *TPartitionValuesMetadataParams) IsSetCatalog() bool {
+	return p.Catalog != nil
+}
+
+func (p *TPartitionValuesMetadataParams) IsSetDatabase() bool {
+	return p.Database != nil
+}
+
+func (p *TPartitionValuesMetadataParams) IsSetTable() bool {
+	return p.Table != nil
+}
+
+func (p *TPartitionValuesMetadataParams) Read(iprot thrift.TProtocol) (err error) {
+
+	var fieldTypeId thrift.TType
+	var fieldId int16
+
+	if _, err = iprot.ReadStructBegin(); err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err = iprot.ReadFieldBegin()
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField1(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 2:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField2(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 3:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField3(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		default:
+			if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		}
+		if err = iprot.ReadFieldEnd(); err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	if err = iprot.ReadStructEnd(); err != nil {
+		goto ReadStructEndError
+	}
+
+	return nil
+ReadStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_TPartitionValuesMetadataParams[fieldId]), err)
+SkipFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+
+ReadFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *TPartitionValuesMetadataParams) ReadField1(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Catalog = _field
+	return nil
+}
+func (p *TPartitionValuesMetadataParams) ReadField2(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Database = _field
+	return nil
+}
+func (p *TPartitionValuesMetadataParams) ReadField3(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Table = _field
+	return nil
+}
+
+func (p *TPartitionValuesMetadataParams) Write(oprot thrift.TProtocol) (err error) {
+	var fieldId int16
+	if err = oprot.WriteStructBegin("TPartitionValuesMetadataParams"); err != nil {
+		goto WriteStructBeginError
+	}
+	if p != nil {
+		if err = p.writeField1(oprot); err != nil {
+			fieldId = 1
+			goto WriteFieldError
+		}
+		if err = p.writeField2(oprot); err != nil {
+			fieldId = 2
+			goto WriteFieldError
+		}
+		if err = p.writeField3(oprot); err != nil {
+			fieldId = 3
+			goto WriteFieldError
+		}
+	}
+	if err = oprot.WriteFieldStop(); err != nil {
+		goto WriteFieldStopError
+	}
+	if err = oprot.WriteStructEnd(); err != nil {
+		goto WriteStructEndError
+	}
+	return nil
+WriteStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+WriteFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T write field %d error: ", p, fieldId), err)
+WriteFieldStopError:
+	return thrift.PrependError(fmt.Sprintf("%T write field stop error: ", p), err)
+WriteStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct end error: ", p), err)
+}
+
+func (p *TPartitionValuesMetadataParams) writeField1(oprot thrift.TProtocol) (err error) {
+	if p.IsSetCatalog() {
+		if err = oprot.WriteFieldBegin("catalog", thrift.STRING, 1); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.Catalog); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 end error: ", p), err)
+}
+
+func (p *TPartitionValuesMetadataParams) writeField2(oprot thrift.TProtocol) (err error) {
+	if p.IsSetDatabase() {
+		if err = oprot.WriteFieldBegin("database", thrift.STRING, 2); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.Database); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 end error: ", p), err)
+}
+
+func (p *TPartitionValuesMetadataParams) writeField3(oprot thrift.TProtocol) (err error) {
+	if p.IsSetTable() {
+		if err = oprot.WriteFieldBegin("table", thrift.STRING, 3); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.Table); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 end error: ", p), err)
+}
+
+func (p *TPartitionValuesMetadataParams) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("TPartitionValuesMetadataParams(%+v)", *p)
+
+}
+
+func (p *TPartitionValuesMetadataParams) DeepEqual(ano *TPartitionValuesMetadataParams) bool {
+	if p == ano {
+		return true
+	} else if p == nil || ano == nil {
+		return false
+	}
+	if !p.Field1DeepEqual(ano.Catalog) {
+		return false
+	}
+	if !p.Field2DeepEqual(ano.Database) {
+		return false
+	}
+	if !p.Field3DeepEqual(ano.Table) {
+		return false
+	}
+	return true
+}
+
+func (p *TPartitionValuesMetadataParams) Field1DeepEqual(src *string) bool {
+
+	if p.Catalog == src {
+		return true
+	} else if p.Catalog == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.Catalog, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TPartitionValuesMetadataParams) Field2DeepEqual(src *string) bool {
+
+	if p.Database == src {
+		return true
+	} else if p.Database == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.Database, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TPartitionValuesMetadataParams) Field3DeepEqual(src *string) bool {
+
+	if p.Table == src {
+		return true
+	} else if p.Table == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.Table, *src) != 0 {
+		return false
+	}
+	return true
+}
+
 type TJobsMetadataParams struct {
 	Type             *string              `thrift:"type,1,optional" frugal:"1,optional,string" json:"type,omitempty"`
 	CurrentUserIdent *types.TUserIdentity `thrift:"current_user_ident,2,optional" frugal:"2,optional,types.TUserIdentity" json:"current_user_ident,omitempty"`
@@ -21325,6 +21879,7 @@ type TQueriesMetadataParams struct {
 	JobsParams              *TJobsMetadataParams              `thrift:"jobs_params,4,optional" frugal:"4,optional,TJobsMetadataParams" json:"jobs_params,omitempty"`
 	TasksParams             *TTasksMetadataParams             `thrift:"tasks_params,5,optional" frugal:"5,optional,TTasksMetadataParams" json:"tasks_params,omitempty"`
 	PartitionsParams        *TPartitionsMetadataParams        `thrift:"partitions_params,6,optional" frugal:"6,optional,TPartitionsMetadataParams" json:"partitions_params,omitempty"`
+	PartitionValuesParams   *TPartitionValuesMetadataParams   `thrift:"partition_values_params,7,optional" frugal:"7,optional,TPartitionValuesMetadataParams" json:"partition_values_params,omitempty"`
 }
 
 func NewTQueriesMetadataParams() *TQueriesMetadataParams {
@@ -21387,6 +21942,15 @@ func (p *TQueriesMetadataParams) GetPartitionsParams() (v *TPartitionsMetadataPa
 	}
 	return p.PartitionsParams
 }
+
+var TQueriesMetadataParams_PartitionValuesParams_DEFAULT *TPartitionValuesMetadataParams
+
+func (p *TQueriesMetadataParams) GetPartitionValuesParams() (v *TPartitionValuesMetadataParams) {
+	if !p.IsSetPartitionValuesParams() {
+		return TQueriesMetadataParams_PartitionValuesParams_DEFAULT
+	}
+	return p.PartitionValuesParams
+}
 func (p *TQueriesMetadataParams) SetClusterName(val *string) {
 	p.ClusterName = val
 }
@@ -21405,6 +21969,9 @@ func (p *TQueriesMetadataParams) SetTasksParams(val *TTasksMetadataParams) {
 func (p *TQueriesMetadataParams) SetPartitionsParams(val *TPartitionsMetadataParams) {
 	p.PartitionsParams = val
 }
+func (p *TQueriesMetadataParams) SetPartitionValuesParams(val *TPartitionValuesMetadataParams) {
+	p.PartitionValuesParams = val
+}
 
 var fieldIDToName_TQueriesMetadataParams = map[int16]string{
 	1: "cluster_name",
@@ -21413,6 +21980,7 @@ var fieldIDToName_TQueriesMetadataParams = map[int16]string{
 	4: "jobs_params",
 	5: "tasks_params",
 	6: "partitions_params",
+	7: "partition_values_params",
 }
 
 func (p *TQueriesMetadataParams) IsSetClusterName() bool {
@@ -21437,6 +22005,10 @@ func (p *TQueriesMetadataParams) IsSetTasksParams() bool {
 
 func (p *TQueriesMetadataParams) IsSetPartitionsParams() bool {
 	return p.PartitionsParams != nil
+}
+
+func (p *TQueriesMetadataParams) IsSetPartitionValuesParams() bool {
+	return p.PartitionValuesParams != nil
 }
 
 func (p *TQueriesMetadataParams) Read(iprot thrift.TProtocol) (err error) {
@@ -21501,6 +22073,14 @@ func (p *TQueriesMetadataParams) Read(iprot thrift.TProtocol) (err error) {
 		case 6:
 			if fieldTypeId == thrift.STRUCT {
 				if err = p.ReadField6(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 7:
+			if fieldTypeId == thrift.STRUCT {
+				if err = p.ReadField7(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -21589,6 +22169,14 @@ func (p *TQueriesMetadataParams) ReadField6(iprot thrift.TProtocol) error {
 	p.PartitionsParams = _field
 	return nil
 }
+func (p *TQueriesMetadataParams) ReadField7(iprot thrift.TProtocol) error {
+	_field := NewTPartitionValuesMetadataParams()
+	if err := _field.Read(iprot); err != nil {
+		return err
+	}
+	p.PartitionValuesParams = _field
+	return nil
+}
 
 func (p *TQueriesMetadataParams) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -21618,6 +22206,10 @@ func (p *TQueriesMetadataParams) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField6(oprot); err != nil {
 			fieldId = 6
+			goto WriteFieldError
+		}
+		if err = p.writeField7(oprot); err != nil {
+			fieldId = 7
 			goto WriteFieldError
 		}
 	}
@@ -21752,6 +22344,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 6 end error: ", p), err)
 }
 
+func (p *TQueriesMetadataParams) writeField7(oprot thrift.TProtocol) (err error) {
+	if p.IsSetPartitionValuesParams() {
+		if err = oprot.WriteFieldBegin("partition_values_params", thrift.STRUCT, 7); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := p.PartitionValuesParams.Write(oprot); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 7 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 7 end error: ", p), err)
+}
+
 func (p *TQueriesMetadataParams) String() string {
 	if p == nil {
 		return "<nil>"
@@ -21782,6 +22393,9 @@ func (p *TQueriesMetadataParams) DeepEqual(ano *TQueriesMetadataParams) bool {
 		return false
 	}
 	if !p.Field6DeepEqual(ano.PartitionsParams) {
+		return false
+	}
+	if !p.Field7DeepEqual(ano.PartitionValuesParams) {
 		return false
 	}
 	return true
@@ -21835,6 +22449,13 @@ func (p *TQueriesMetadataParams) Field5DeepEqual(src *TTasksMetadataParams) bool
 func (p *TQueriesMetadataParams) Field6DeepEqual(src *TPartitionsMetadataParams) bool {
 
 	if !p.PartitionsParams.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+func (p *TQueriesMetadataParams) Field7DeepEqual(src *TPartitionValuesMetadataParams) bool {
+
+	if !p.PartitionValuesParams.DeepEqual(src) {
 		return false
 	}
 	return true
@@ -21943,6 +22564,7 @@ type TMetaScanRange struct {
 	TasksParams             *TTasksMetadataParams             `thrift:"tasks_params,8,optional" frugal:"8,optional,TTasksMetadataParams" json:"tasks_params,omitempty"`
 	PartitionsParams        *TPartitionsMetadataParams        `thrift:"partitions_params,9,optional" frugal:"9,optional,TPartitionsMetadataParams" json:"partitions_params,omitempty"`
 	MetaCacheStatsParams    *TMetaCacheStatsParams            `thrift:"meta_cache_stats_params,10,optional" frugal:"10,optional,TMetaCacheStatsParams" json:"meta_cache_stats_params,omitempty"`
+	PartitionValuesParams   *TPartitionValuesMetadataParams   `thrift:"partition_values_params,11,optional" frugal:"11,optional,TPartitionValuesMetadataParams" json:"partition_values_params,omitempty"`
 }
 
 func NewTMetaScanRange() *TMetaScanRange {
@@ -22041,6 +22663,15 @@ func (p *TMetaScanRange) GetMetaCacheStatsParams() (v *TMetaCacheStatsParams) {
 	}
 	return p.MetaCacheStatsParams
 }
+
+var TMetaScanRange_PartitionValuesParams_DEFAULT *TPartitionValuesMetadataParams
+
+func (p *TMetaScanRange) GetPartitionValuesParams() (v *TPartitionValuesMetadataParams) {
+	if !p.IsSetPartitionValuesParams() {
+		return TMetaScanRange_PartitionValuesParams_DEFAULT
+	}
+	return p.PartitionValuesParams
+}
 func (p *TMetaScanRange) SetMetadataType(val *types.TMetadataType) {
 	p.MetadataType = val
 }
@@ -22071,6 +22702,9 @@ func (p *TMetaScanRange) SetPartitionsParams(val *TPartitionsMetadataParams) {
 func (p *TMetaScanRange) SetMetaCacheStatsParams(val *TMetaCacheStatsParams) {
 	p.MetaCacheStatsParams = val
 }
+func (p *TMetaScanRange) SetPartitionValuesParams(val *TPartitionValuesMetadataParams) {
+	p.PartitionValuesParams = val
+}
 
 var fieldIDToName_TMetaScanRange = map[int16]string{
 	1:  "metadata_type",
@@ -22083,6 +22717,7 @@ var fieldIDToName_TMetaScanRange = map[int16]string{
 	8:  "tasks_params",
 	9:  "partitions_params",
 	10: "meta_cache_stats_params",
+	11: "partition_values_params",
 }
 
 func (p *TMetaScanRange) IsSetMetadataType() bool {
@@ -22123,6 +22758,10 @@ func (p *TMetaScanRange) IsSetPartitionsParams() bool {
 
 func (p *TMetaScanRange) IsSetMetaCacheStatsParams() bool {
 	return p.MetaCacheStatsParams != nil
+}
+
+func (p *TMetaScanRange) IsSetPartitionValuesParams() bool {
+	return p.PartitionValuesParams != nil
 }
 
 func (p *TMetaScanRange) Read(iprot thrift.TProtocol) (err error) {
@@ -22219,6 +22858,14 @@ func (p *TMetaScanRange) Read(iprot thrift.TProtocol) (err error) {
 		case 10:
 			if fieldTypeId == thrift.STRUCT {
 				if err = p.ReadField10(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 11:
+			if fieldTypeId == thrift.STRUCT {
+				if err = p.ReadField11(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -22337,6 +22984,14 @@ func (p *TMetaScanRange) ReadField10(iprot thrift.TProtocol) error {
 	p.MetaCacheStatsParams = _field
 	return nil
 }
+func (p *TMetaScanRange) ReadField11(iprot thrift.TProtocol) error {
+	_field := NewTPartitionValuesMetadataParams()
+	if err := _field.Read(iprot); err != nil {
+		return err
+	}
+	p.PartitionValuesParams = _field
+	return nil
+}
 
 func (p *TMetaScanRange) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -22382,6 +23037,10 @@ func (p *TMetaScanRange) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField10(oprot); err != nil {
 			fieldId = 10
+			goto WriteFieldError
+		}
+		if err = p.writeField11(oprot); err != nil {
+			fieldId = 11
 			goto WriteFieldError
 		}
 	}
@@ -22592,6 +23251,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 10 end error: ", p), err)
 }
 
+func (p *TMetaScanRange) writeField11(oprot thrift.TProtocol) (err error) {
+	if p.IsSetPartitionValuesParams() {
+		if err = oprot.WriteFieldBegin("partition_values_params", thrift.STRUCT, 11); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := p.PartitionValuesParams.Write(oprot); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 11 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 11 end error: ", p), err)
+}
+
 func (p *TMetaScanRange) String() string {
 	if p == nil {
 		return "<nil>"
@@ -22634,6 +23312,9 @@ func (p *TMetaScanRange) DeepEqual(ano *TMetaScanRange) bool {
 		return false
 	}
 	if !p.Field10DeepEqual(ano.MetaCacheStatsParams) {
+		return false
+	}
+	if !p.Field11DeepEqual(ano.PartitionValuesParams) {
 		return false
 	}
 	return true
@@ -22710,6 +23391,13 @@ func (p *TMetaScanRange) Field9DeepEqual(src *TPartitionsMetadataParams) bool {
 func (p *TMetaScanRange) Field10DeepEqual(src *TMetaCacheStatsParams) bool {
 
 	if !p.MetaCacheStatsParams.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+func (p *TMetaScanRange) Field11DeepEqual(src *TPartitionValuesMetadataParams) bool {
+
+	if !p.PartitionValuesParams.DeepEqual(src) {
 		return false
 	}
 	return true
@@ -44713,6 +45401,7 @@ type TPlanNode struct {
 	PushDownAggTypeOpt            *TPushAggOp              `thrift:"push_down_agg_type_opt,48,optional" frugal:"48,optional,TPushAggOp" json:"push_down_agg_type_opt,omitempty"`
 	PushDownCount                 *int64                   `thrift:"push_down_count,49,optional" frugal:"49,optional,i64" json:"push_down_count,omitempty"`
 	DistributeExprLists           [][]*exprs.TExpr         `thrift:"distribute_expr_lists,50,optional" frugal:"50,optional,list<list<exprs.TExpr>>" json:"distribute_expr_lists,omitempty"`
+	IsSerialOperator              *bool                    `thrift:"is_serial_operator,51,optional" frugal:"51,optional,bool" json:"is_serial_operator,omitempty"`
 	Projections                   []*exprs.TExpr           `thrift:"projections,101,optional" frugal:"101,optional,list<exprs.TExpr>" json:"projections,omitempty"`
 	OutputTupleId                 *types.TTupleId          `thrift:"output_tuple_id,102,optional" frugal:"102,optional,i32" json:"output_tuple_id,omitempty"`
 	PartitionSortNode             *TPartitionSortNode      `thrift:"partition_sort_node,103,optional" frugal:"103,optional,TPartitionSortNode" json:"partition_sort_node,omitempty"`
@@ -45090,6 +45779,15 @@ func (p *TPlanNode) GetDistributeExprLists() (v [][]*exprs.TExpr) {
 	return p.DistributeExprLists
 }
 
+var TPlanNode_IsSerialOperator_DEFAULT bool
+
+func (p *TPlanNode) GetIsSerialOperator() (v bool) {
+	if !p.IsSetIsSerialOperator() {
+		return TPlanNode_IsSerialOperator_DEFAULT
+	}
+	return *p.IsSerialOperator
+}
+
 var TPlanNode_Projections_DEFAULT []*exprs.TExpr
 
 func (p *TPlanNode) GetProjections() (v []*exprs.TExpr) {
@@ -45284,6 +45982,9 @@ func (p *TPlanNode) SetPushDownCount(val *int64) {
 func (p *TPlanNode) SetDistributeExprLists(val [][]*exprs.TExpr) {
 	p.DistributeExprLists = val
 }
+func (p *TPlanNode) SetIsSerialOperator(val *bool) {
+	p.IsSerialOperator = val
+}
 func (p *TPlanNode) SetProjections(val []*exprs.TExpr) {
 	p.Projections = val
 }
@@ -45351,6 +46052,7 @@ var fieldIDToName_TPlanNode = map[int16]string{
 	48:  "push_down_agg_type_opt",
 	49:  "push_down_count",
 	50:  "distribute_expr_lists",
+	51:  "is_serial_operator",
 	101: "projections",
 	102: "output_tuple_id",
 	103: "partition_sort_node",
@@ -45506,6 +46208,10 @@ func (p *TPlanNode) IsSetPushDownCount() bool {
 
 func (p *TPlanNode) IsSetDistributeExprLists() bool {
 	return p.DistributeExprLists != nil
+}
+
+func (p *TPlanNode) IsSetIsSerialOperator() bool {
+	return p.IsSerialOperator != nil
 }
 
 func (p *TPlanNode) IsSetProjections() bool {
@@ -45916,6 +46622,14 @@ func (p *TPlanNode) Read(iprot thrift.TProtocol) (err error) {
 		case 50:
 			if fieldTypeId == thrift.LIST {
 				if err = p.ReadField50(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 51:
+			if fieldTypeId == thrift.BOOL {
+				if err = p.ReadField51(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -46518,6 +47232,17 @@ func (p *TPlanNode) ReadField50(iprot thrift.TProtocol) error {
 	p.DistributeExprLists = _field
 	return nil
 }
+func (p *TPlanNode) ReadField51(iprot thrift.TProtocol) error {
+
+	var _field *bool
+	if v, err := iprot.ReadBool(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.IsSerialOperator = _field
+	return nil
+}
 func (p *TPlanNode) ReadField101(iprot thrift.TProtocol) error {
 	_, size, err := iprot.ReadListBegin()
 	if err != nil {
@@ -46833,6 +47558,10 @@ func (p *TPlanNode) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField50(oprot); err != nil {
 			fieldId = 50
+			goto WriteFieldError
+		}
+		if err = p.writeField51(oprot); err != nil {
+			fieldId = 51
 			goto WriteFieldError
 		}
 		if err = p.writeField101(oprot); err != nil {
@@ -47759,6 +48488,25 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 50 end error: ", p), err)
 }
 
+func (p *TPlanNode) writeField51(oprot thrift.TProtocol) (err error) {
+	if p.IsSetIsSerialOperator() {
+		if err = oprot.WriteFieldBegin("is_serial_operator", thrift.BOOL, 51); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteBool(*p.IsSerialOperator); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 51 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 51 end error: ", p), err)
+}
+
 func (p *TPlanNode) writeField101(oprot thrift.TProtocol) (err error) {
 	if p.IsSetProjections() {
 		if err = oprot.WriteFieldBegin("projections", thrift.LIST, 101); err != nil {
@@ -48076,6 +48824,9 @@ func (p *TPlanNode) DeepEqual(ano *TPlanNode) bool {
 		return false
 	}
 	if !p.Field50DeepEqual(ano.DistributeExprLists) {
+		return false
+	}
+	if !p.Field51DeepEqual(ano.IsSerialOperator) {
 		return false
 	}
 	if !p.Field101DeepEqual(ano.Projections) {
@@ -48459,6 +49210,18 @@ func (p *TPlanNode) Field50DeepEqual(src [][]*exprs.TExpr) bool {
 				return false
 			}
 		}
+	}
+	return true
+}
+func (p *TPlanNode) Field51DeepEqual(src *bool) bool {
+
+	if p.IsSerialOperator == src {
+		return true
+	} else if p.IsSerialOperator == nil || src == nil {
+		return false
+	}
+	if *p.IsSerialOperator != *src {
+		return false
 	}
 	return true
 }

--- a/pkg/rpc/kitex_gen/plannodes/k-PlanNodes.go
+++ b/pkg/rpc/kitex_gen/plannodes/k-PlanNodes.go
@@ -4474,6 +4474,20 @@ func (p *TFileTextScanRangeParams) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 7:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField7(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -4587,6 +4601,19 @@ func (p *TFileTextScanRangeParams) FastReadField6(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TFileTextScanRangeParams) FastReadField7(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.NullFormat = &v
+
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TFileTextScanRangeParams) FastWrite(buf []byte) int {
 	return 0
@@ -4602,6 +4629,7 @@ func (p *TFileTextScanRangeParams) FastWriteNocopy(buf []byte, binaryWriter bthr
 		offset += p.fastWriteField2(buf[offset:], binaryWriter)
 		offset += p.fastWriteField3(buf[offset:], binaryWriter)
 		offset += p.fastWriteField4(buf[offset:], binaryWriter)
+		offset += p.fastWriteField7(buf[offset:], binaryWriter)
 	}
 	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
 	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
@@ -4618,6 +4646,7 @@ func (p *TFileTextScanRangeParams) BLength() int {
 		l += p.field4Length()
 		l += p.field5Length()
 		l += p.field6Length()
+		l += p.field7Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -4690,6 +4719,17 @@ func (p *TFileTextScanRangeParams) fastWriteField6(buf []byte, binaryWriter bthr
 	return offset
 }
 
+func (p *TFileTextScanRangeParams) fastWriteField7(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetNullFormat() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "null_format", thrift.STRING, 7)
+		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.NullFormat)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TFileTextScanRangeParams) field1Length() int {
 	l := 0
 	if p.IsSetColumnSeparator() {
@@ -4750,6 +4790,17 @@ func (p *TFileTextScanRangeParams) field6Length() int {
 	if p.IsSetEscape() {
 		l += bthrift.Binary.FieldBeginLength("escape", thrift.BYTE, 6)
 		l += bthrift.Binary.ByteLength(*p.Escape)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TFileTextScanRangeParams) field7Length() int {
+	l := 0
+	if p.IsSetNullFormat() {
+		l += bthrift.Binary.FieldBeginLength("null_format", thrift.STRING, 7)
+		l += bthrift.Binary.StringLengthNocopy(*p.NullFormat)
 
 		l += bthrift.Binary.FieldEndLength()
 	}
@@ -6102,6 +6153,20 @@ func (p *TIcebergFileDesc) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 7:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField7(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -6229,6 +6294,19 @@ func (p *TIcebergFileDesc) FastReadField6(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TIcebergFileDesc) FastReadField7(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.RowCount = &v
+
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TIcebergFileDesc) FastWrite(buf []byte) int {
 	return 0
@@ -6241,6 +6319,7 @@ func (p *TIcebergFileDesc) FastWriteNocopy(buf []byte, binaryWriter bthrift.Bina
 		offset += p.fastWriteField1(buf[offset:], binaryWriter)
 		offset += p.fastWriteField2(buf[offset:], binaryWriter)
 		offset += p.fastWriteField4(buf[offset:], binaryWriter)
+		offset += p.fastWriteField7(buf[offset:], binaryWriter)
 		offset += p.fastWriteField3(buf[offset:], binaryWriter)
 		offset += p.fastWriteField5(buf[offset:], binaryWriter)
 		offset += p.fastWriteField6(buf[offset:], binaryWriter)
@@ -6260,6 +6339,7 @@ func (p *TIcebergFileDesc) BLength() int {
 		l += p.field4Length()
 		l += p.field5Length()
 		l += p.field6Length()
+		l += p.field7Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -6338,6 +6418,17 @@ func (p *TIcebergFileDesc) fastWriteField6(buf []byte, binaryWriter bthrift.Bina
 	return offset
 }
 
+func (p *TIcebergFileDesc) fastWriteField7(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetRowCount() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "row_count", thrift.I64, 7)
+		offset += bthrift.Binary.WriteI64(buf[offset:], *p.RowCount)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TIcebergFileDesc) field1Length() int {
 	l := 0
 	if p.IsSetFormatVersion() {
@@ -6400,6 +6491,17 @@ func (p *TIcebergFileDesc) field6Length() int {
 	if p.IsSetOriginalFilePath() {
 		l += bthrift.Binary.FieldBeginLength("original_file_path", thrift.STRING, 6)
 		l += bthrift.Binary.StringLengthNocopy(*p.OriginalFilePath)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TIcebergFileDesc) field7Length() int {
+	l := 0
+	if p.IsSetRowCount() {
+		l += bthrift.Binary.FieldBeginLength("row_count", thrift.I64, 7)
+		l += bthrift.Binary.I64Length(*p.RowCount)
 
 		l += bthrift.Binary.FieldEndLength()
 	}
@@ -10756,6 +10858,20 @@ func (p *TFileScanRangeParams) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 23:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField23(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -11271,6 +11387,19 @@ func (p *TFileScanRangeParams) FastReadField22(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TFileScanRangeParams) FastReadField23(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.SequenceMapCol = &v
+
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TFileScanRangeParams) FastWrite(buf []byte) int {
 	return 0
@@ -11302,6 +11431,7 @@ func (p *TFileScanRangeParams) FastWriteNocopy(buf []byte, binaryWriter bthrift.
 		offset += p.fastWriteField20(buf[offset:], binaryWriter)
 		offset += p.fastWriteField21(buf[offset:], binaryWriter)
 		offset += p.fastWriteField22(buf[offset:], binaryWriter)
+		offset += p.fastWriteField23(buf[offset:], binaryWriter)
 	}
 	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
 	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
@@ -11334,6 +11464,7 @@ func (p *TFileScanRangeParams) BLength() int {
 		l += p.field20Length()
 		l += p.field21Length()
 		l += p.field22Length()
+		l += p.field23Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -11659,6 +11790,17 @@ func (p *TFileScanRangeParams) fastWriteField22(buf []byte, binaryWriter bthrift
 	return offset
 }
 
+func (p *TFileScanRangeParams) fastWriteField23(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetSequenceMapCol() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "sequence_map_col", thrift.STRING, 23)
+		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.SequenceMapCol)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TFileScanRangeParams) field1Length() int {
 	l := 0
 	if p.IsSetFileType() {
@@ -11930,6 +12072,17 @@ func (p *TFileScanRangeParams) field22Length() int {
 	if p.IsSetTextSerdeType() {
 		l += bthrift.Binary.FieldBeginLength("text_serde_type", thrift.I32, 22)
 		l += bthrift.Binary.I32Length(int32(*p.TextSerdeType))
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TFileScanRangeParams) field23Length() int {
+	l := 0
+	if p.IsSetSequenceMapCol() {
+		l += bthrift.Binary.FieldBeginLength("sequence_map_col", thrift.STRING, 23)
+		l += bthrift.Binary.StringLengthNocopy(*p.SequenceMapCol)
 
 		l += bthrift.Binary.FieldEndLength()
 	}
@@ -14596,6 +14749,241 @@ func (p *TPartitionsMetadataParams) field3Length() int {
 	return l
 }
 
+func (p *TPartitionValuesMetadataParams) FastRead(buf []byte) (int, error) {
+	var err error
+	var offset int
+	var l int
+	var fieldTypeId thrift.TType
+	var fieldId int16
+	_, l, err = bthrift.Binary.ReadStructBegin(buf)
+	offset += l
+	if err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, l, err = bthrift.Binary.ReadFieldBegin(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField1(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 2:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField2(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 3:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField3(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		default:
+			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+			offset += l
+			if err != nil {
+				goto SkipFieldError
+			}
+		}
+
+		l, err = bthrift.Binary.ReadFieldEnd(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	l, err = bthrift.Binary.ReadStructEnd(buf[offset:])
+	offset += l
+	if err != nil {
+		goto ReadStructEndError
+	}
+
+	return offset, nil
+ReadStructBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_TPartitionValuesMetadataParams[fieldId]), err)
+SkipFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+ReadFieldEndError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *TPartitionValuesMetadataParams) FastReadField1(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.Catalog = &v
+
+	}
+	return offset, nil
+}
+
+func (p *TPartitionValuesMetadataParams) FastReadField2(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.Database = &v
+
+	}
+	return offset, nil
+}
+
+func (p *TPartitionValuesMetadataParams) FastReadField3(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.Table = &v
+
+	}
+	return offset, nil
+}
+
+// for compatibility
+func (p *TPartitionValuesMetadataParams) FastWrite(buf []byte) int {
+	return 0
+}
+
+func (p *TPartitionValuesMetadataParams) FastWriteNocopy(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	offset += bthrift.Binary.WriteStructBegin(buf[offset:], "TPartitionValuesMetadataParams")
+	if p != nil {
+		offset += p.fastWriteField1(buf[offset:], binaryWriter)
+		offset += p.fastWriteField2(buf[offset:], binaryWriter)
+		offset += p.fastWriteField3(buf[offset:], binaryWriter)
+	}
+	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
+	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
+	return offset
+}
+
+func (p *TPartitionValuesMetadataParams) BLength() int {
+	l := 0
+	l += bthrift.Binary.StructBeginLength("TPartitionValuesMetadataParams")
+	if p != nil {
+		l += p.field1Length()
+		l += p.field2Length()
+		l += p.field3Length()
+	}
+	l += bthrift.Binary.FieldStopLength()
+	l += bthrift.Binary.StructEndLength()
+	return l
+}
+
+func (p *TPartitionValuesMetadataParams) fastWriteField1(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetCatalog() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "catalog", thrift.STRING, 1)
+		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.Catalog)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TPartitionValuesMetadataParams) fastWriteField2(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetDatabase() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "database", thrift.STRING, 2)
+		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.Database)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TPartitionValuesMetadataParams) fastWriteField3(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetTable() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "table", thrift.STRING, 3)
+		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.Table)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TPartitionValuesMetadataParams) field1Length() int {
+	l := 0
+	if p.IsSetCatalog() {
+		l += bthrift.Binary.FieldBeginLength("catalog", thrift.STRING, 1)
+		l += bthrift.Binary.StringLengthNocopy(*p.Catalog)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TPartitionValuesMetadataParams) field2Length() int {
+	l := 0
+	if p.IsSetDatabase() {
+		l += bthrift.Binary.FieldBeginLength("database", thrift.STRING, 2)
+		l += bthrift.Binary.StringLengthNocopy(*p.Database)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TPartitionValuesMetadataParams) field3Length() int {
+	l := 0
+	if p.IsSetTable() {
+		l += bthrift.Binary.FieldBeginLength("table", thrift.STRING, 3)
+		l += bthrift.Binary.StringLengthNocopy(*p.Table)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
 func (p *TJobsMetadataParams) FastRead(buf []byte) (int, error) {
 	var err error
 	var offset int
@@ -15066,6 +15454,20 @@ func (p *TQueriesMetadataParams) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 7:
+			if fieldTypeId == thrift.STRUCT {
+				l, err = p.FastReadField7(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -15179,6 +15581,19 @@ func (p *TQueriesMetadataParams) FastReadField6(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TQueriesMetadataParams) FastReadField7(buf []byte) (int, error) {
+	offset := 0
+
+	tmp := NewTPartitionValuesMetadataParams()
+	if l, err := tmp.FastRead(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	p.PartitionValuesParams = tmp
+	return offset, nil
+}
+
 // for compatibility
 func (p *TQueriesMetadataParams) FastWrite(buf []byte) int {
 	return 0
@@ -15194,6 +15609,7 @@ func (p *TQueriesMetadataParams) FastWriteNocopy(buf []byte, binaryWriter bthrif
 		offset += p.fastWriteField4(buf[offset:], binaryWriter)
 		offset += p.fastWriteField5(buf[offset:], binaryWriter)
 		offset += p.fastWriteField6(buf[offset:], binaryWriter)
+		offset += p.fastWriteField7(buf[offset:], binaryWriter)
 	}
 	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
 	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
@@ -15210,6 +15626,7 @@ func (p *TQueriesMetadataParams) BLength() int {
 		l += p.field4Length()
 		l += p.field5Length()
 		l += p.field6Length()
+		l += p.field7Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -15278,6 +15695,16 @@ func (p *TQueriesMetadataParams) fastWriteField6(buf []byte, binaryWriter bthrif
 	return offset
 }
 
+func (p *TQueriesMetadataParams) fastWriteField7(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetPartitionValuesParams() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "partition_values_params", thrift.STRUCT, 7)
+		offset += p.PartitionValuesParams.FastWriteNocopy(buf[offset:], binaryWriter)
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TQueriesMetadataParams) field1Length() int {
 	l := 0
 	if p.IsSetClusterName() {
@@ -15335,6 +15762,16 @@ func (p *TQueriesMetadataParams) field6Length() int {
 	if p.IsSetPartitionsParams() {
 		l += bthrift.Binary.FieldBeginLength("partitions_params", thrift.STRUCT, 6)
 		l += p.PartitionsParams.BLength()
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TQueriesMetadataParams) field7Length() int {
+	l := 0
+	if p.IsSetPartitionValuesParams() {
+		l += bthrift.Binary.FieldBeginLength("partition_values_params", thrift.STRUCT, 7)
+		l += p.PartitionValuesParams.BLength()
 		l += bthrift.Binary.FieldEndLength()
 	}
 	return l
@@ -15579,6 +16016,20 @@ func (p *TMetaScanRange) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 11:
+			if fieldTypeId == thrift.STRUCT {
+				l, err = p.FastReadField11(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -15746,6 +16197,19 @@ func (p *TMetaScanRange) FastReadField10(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TMetaScanRange) FastReadField11(buf []byte) (int, error) {
+	offset := 0
+
+	tmp := NewTPartitionValuesMetadataParams()
+	if l, err := tmp.FastRead(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	p.PartitionValuesParams = tmp
+	return offset, nil
+}
+
 // for compatibility
 func (p *TMetaScanRange) FastWrite(buf []byte) int {
 	return 0
@@ -15765,6 +16229,7 @@ func (p *TMetaScanRange) FastWriteNocopy(buf []byte, binaryWriter bthrift.Binary
 		offset += p.fastWriteField8(buf[offset:], binaryWriter)
 		offset += p.fastWriteField9(buf[offset:], binaryWriter)
 		offset += p.fastWriteField10(buf[offset:], binaryWriter)
+		offset += p.fastWriteField11(buf[offset:], binaryWriter)
 	}
 	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
 	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
@@ -15785,6 +16250,7 @@ func (p *TMetaScanRange) BLength() int {
 		l += p.field8Length()
 		l += p.field9Length()
 		l += p.field10Length()
+		l += p.field11Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -15892,6 +16358,16 @@ func (p *TMetaScanRange) fastWriteField10(buf []byte, binaryWriter bthrift.Binar
 	return offset
 }
 
+func (p *TMetaScanRange) fastWriteField11(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetPartitionValuesParams() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "partition_values_params", thrift.STRUCT, 11)
+		offset += p.PartitionValuesParams.FastWriteNocopy(buf[offset:], binaryWriter)
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TMetaScanRange) field1Length() int {
 	l := 0
 	if p.IsSetMetadataType() {
@@ -15988,6 +16464,16 @@ func (p *TMetaScanRange) field10Length() int {
 	if p.IsSetMetaCacheStatsParams() {
 		l += bthrift.Binary.FieldBeginLength("meta_cache_stats_params", thrift.STRUCT, 10)
 		l += p.MetaCacheStatsParams.BLength()
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TMetaScanRange) field11Length() int {
+	l := 0
+	if p.IsSetPartitionValuesParams() {
+		l += bthrift.Binary.FieldBeginLength("partition_values_params", thrift.STRUCT, 11)
+		l += p.PartitionValuesParams.BLength()
 		l += bthrift.Binary.FieldEndLength()
 	}
 	return l
@@ -33755,6 +34241,20 @@ func (p *TPlanNode) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 51:
+			if fieldTypeId == thrift.BOOL {
+				l, err = p.FastReadField51(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		case 101:
 			if fieldTypeId == thrift.LIST {
 				l, err = p.FastReadField101(buf[offset:])
@@ -34611,6 +35111,19 @@ func (p *TPlanNode) FastReadField50(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TPlanNode) FastReadField51(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadBool(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.IsSerialOperator = &v
+
+	}
+	return offset, nil
+}
+
 func (p *TPlanNode) FastReadField101(buf []byte) (int, error) {
 	offset := 0
 
@@ -34793,6 +35306,7 @@ func (p *TPlanNode) FastWriteNocopy(buf []byte, binaryWriter bthrift.BinaryWrite
 		offset += p.fastWriteField4(buf[offset:], binaryWriter)
 		offset += p.fastWriteField8(buf[offset:], binaryWriter)
 		offset += p.fastWriteField49(buf[offset:], binaryWriter)
+		offset += p.fastWriteField51(buf[offset:], binaryWriter)
 		offset += p.fastWriteField102(buf[offset:], binaryWriter)
 		offset += p.fastWriteField107(buf[offset:], binaryWriter)
 		offset += p.fastWriteField2(buf[offset:], binaryWriter)
@@ -34893,6 +35407,7 @@ func (p *TPlanNode) BLength() int {
 		l += p.field48Length()
 		l += p.field49Length()
 		l += p.field50Length()
+		l += p.field51Length()
 		l += p.field101Length()
 		l += p.field102Length()
 		l += p.field103Length()
@@ -35393,6 +35908,17 @@ func (p *TPlanNode) fastWriteField50(buf []byte, binaryWriter bthrift.BinaryWrit
 		}
 		bthrift.Binary.WriteListBegin(buf[listBeginOffset:], thrift.LIST, length)
 		offset += bthrift.Binary.WriteListEnd(buf[offset:])
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TPlanNode) fastWriteField51(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetIsSerialOperator() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "is_serial_operator", thrift.BOOL, 51)
+		offset += bthrift.Binary.WriteBool(buf[offset:], *p.IsSerialOperator)
+
 		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
 	}
 	return offset
@@ -35965,6 +36491,17 @@ func (p *TPlanNode) field50Length() int {
 			l += bthrift.Binary.ListEndLength()
 		}
 		l += bthrift.Binary.ListEndLength()
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TPlanNode) field51Length() int {
+	l := 0
+	if p.IsSetIsSerialOperator() {
+		l += bthrift.Binary.FieldBeginLength("is_serial_operator", thrift.BOOL, 51)
+		l += bthrift.Binary.BoolLength(*p.IsSerialOperator)
+
 		l += bthrift.Binary.FieldEndLength()
 	}
 	return l

--- a/pkg/rpc/kitex_gen/types/Types.go
+++ b/pkg/rpc/kitex_gen/types/Types.go
@@ -1281,6 +1281,7 @@ const (
 	TOdbcTableType_OCEANBASE_ORACLE TOdbcTableType = 11
 	TOdbcTableType_NEBULA           TOdbcTableType = 12
 	TOdbcTableType_DB2              TOdbcTableType = 13
+	TOdbcTableType_GBASE            TOdbcTableType = 14
 )
 
 func (p TOdbcTableType) String() string {
@@ -1313,6 +1314,8 @@ func (p TOdbcTableType) String() string {
 		return "NEBULA"
 	case TOdbcTableType_DB2:
 		return "DB2"
+	case TOdbcTableType_GBASE:
+		return "GBASE"
 	}
 	return "<UNSET>"
 }
@@ -1347,6 +1350,8 @@ func TOdbcTableTypeFromString(s string) (TOdbcTableType, error) {
 		return TOdbcTableType_NEBULA, nil
 	case "DB2":
 		return TOdbcTableType_DB2, nil
+	case "GBASE":
+		return TOdbcTableType_GBASE, nil
 	}
 	return TOdbcTableType(0), fmt.Errorf("not a valid TOdbcTableType string")
 }
@@ -1931,6 +1936,53 @@ func (p *TMergeType) Value() (driver.Value, error) {
 	return int64(*p), nil
 }
 
+type TUniqueKeyUpdateMode int64
+
+const (
+	TUniqueKeyUpdateMode_UPSERT                  TUniqueKeyUpdateMode = 0
+	TUniqueKeyUpdateMode_UPDATE_FIXED_COLUMNS    TUniqueKeyUpdateMode = 1
+	TUniqueKeyUpdateMode_UPDATE_FLEXIBLE_COLUMNS TUniqueKeyUpdateMode = 2
+)
+
+func (p TUniqueKeyUpdateMode) String() string {
+	switch p {
+	case TUniqueKeyUpdateMode_UPSERT:
+		return "UPSERT"
+	case TUniqueKeyUpdateMode_UPDATE_FIXED_COLUMNS:
+		return "UPDATE_FIXED_COLUMNS"
+	case TUniqueKeyUpdateMode_UPDATE_FLEXIBLE_COLUMNS:
+		return "UPDATE_FLEXIBLE_COLUMNS"
+	}
+	return "<UNSET>"
+}
+
+func TUniqueKeyUpdateModeFromString(s string) (TUniqueKeyUpdateMode, error) {
+	switch s {
+	case "UPSERT":
+		return TUniqueKeyUpdateMode_UPSERT, nil
+	case "UPDATE_FIXED_COLUMNS":
+		return TUniqueKeyUpdateMode_UPDATE_FIXED_COLUMNS, nil
+	case "UPDATE_FLEXIBLE_COLUMNS":
+		return TUniqueKeyUpdateMode_UPDATE_FLEXIBLE_COLUMNS, nil
+	}
+	return TUniqueKeyUpdateMode(0), fmt.Errorf("not a valid TUniqueKeyUpdateMode string")
+}
+
+func TUniqueKeyUpdateModePtr(v TUniqueKeyUpdateMode) *TUniqueKeyUpdateMode { return &v }
+func (p *TUniqueKeyUpdateMode) Scan(value interface{}) (err error) {
+	var result sql.NullInt64
+	err = result.Scan(value)
+	*p = TUniqueKeyUpdateMode(result.Int64)
+	return
+}
+
+func (p *TUniqueKeyUpdateMode) Value() (driver.Value, error) {
+	if p == nil {
+		return nil, nil
+	}
+	return int64(*p), nil
+}
+
 type TSortType int64
 
 const (
@@ -1986,6 +2038,7 @@ const (
 	TMetadataType_TASKS                 TMetadataType = 7
 	TMetadataType_WORKLOAD_SCHED_POLICY TMetadataType = 8
 	TMetadataType_PARTITIONS            TMetadataType = 9
+	TMetadataType_PARTITION_VALUES      TMetadataType = 10
 )
 
 func (p TMetadataType) String() string {
@@ -2010,6 +2063,8 @@ func (p TMetadataType) String() string {
 		return "WORKLOAD_SCHED_POLICY"
 	case TMetadataType_PARTITIONS:
 		return "PARTITIONS"
+	case TMetadataType_PARTITION_VALUES:
+		return "PARTITION_VALUES"
 	}
 	return "<UNSET>"
 }
@@ -2036,6 +2091,8 @@ func TMetadataTypeFromString(s string) (TMetadataType, error) {
 		return TMetadataType_WORKLOAD_SCHED_POLICY, nil
 	case "PARTITIONS":
 		return TMetadataType_PARTITIONS, nil
+	case "PARTITION_VALUES":
+		return TMetadataType_PARTITION_VALUES, nil
 	}
 	return TMetadataType(0), fmt.Errorf("not a valid TMetadataType string")
 }

--- a/pkg/rpc/thrift/Data.thrift
+++ b/pkg/rpc/thrift/Data.thrift
@@ -54,6 +54,7 @@ struct TCell {
   3: optional i64 longVal
   4: optional double doubleVal
   5: optional string stringVal
+  6: optional bool isNull
   // add type: date datetime
 }
 

--- a/pkg/rpc/thrift/Descriptors.thrift
+++ b/pkg/rpc/thrift/Descriptors.thrift
@@ -228,6 +228,7 @@ struct TOlapTableIndex {
   4: optional string comment
   5: optional i64 index_id
   6: optional map<string, string> properties
+  7: optional list<i32> column_unique_ids
 }
 
 struct TOlapTableIndexSchema {
@@ -249,12 +250,14 @@ struct TOlapTableSchemaParam {
     5: required TTupleDescriptor tuple_desc
     6: required list<TOlapTableIndexSchema> indexes
     7: optional bool is_dynamic_schema // deprecated
-    8: optional bool is_partial_update
+    8: optional bool is_partial_update // deprecated, use unique_key_update_mode
     9: optional list<string> partial_update_input_columns
     10: optional bool is_strict_mode = false
     11: optional string auto_increment_column
     12: optional i32 auto_increment_column_unique_id = -1
     13: optional Types.TInvertedIndexFileStorageFormat inverted_index_file_storage_format = Types.TInvertedIndexFileStorageFormat.V1
+    14: optional Types.TUniqueKeyUpdateMode unique_key_update_mode
+    15: optional i32 sequence_map_col_unique_id = -1
 }
 
 struct TTabletLocation {

--- a/pkg/rpc/thrift/FrontendService.thrift
+++ b/pkg/rpc/thrift/FrontendService.thrift
@@ -437,6 +437,8 @@ struct TQueryProfile {
 struct TFragmentInstanceReport {
   1: optional Types.TUniqueId fragment_instance_id;
   2: optional i32 num_finished_range;
+  3: optional i64 loaded_rows
+  4: optional i64 loaded_bytes
 }
 
 
@@ -759,6 +761,7 @@ struct TStreamLoadPutRequest {
     54: optional bool group_commit // deprecated
     55: optional i32 stream_per_node;
     56: optional string group_commit_mode
+    57: optional Types.TUniqueKeyUpdateMode unique_key_update_mode
 
     // For cloud
     1000: optional string cloud_cluster
@@ -1029,6 +1032,7 @@ struct TMetadataTableRequestParams {
   10: optional PlanNodes.TTasksMetadataParams tasks_metadata_params
   11: optional PlanNodes.TPartitionsMetadataParams partitions_metadata_params
   12: optional PlanNodes.TMetaCacheStatsParams meta_cache_stats_params
+  13: optional PlanNodes.TPartitionValuesMetadataParams partition_values_metadata_params
 }
 
 struct TSchemaTableRequestParams {
@@ -1233,6 +1237,7 @@ struct TGetSnapshotRequest {
     7: optional string label_name
     8: optional string snapshot_name
     9: optional TSnapshotType snapshot_type
+    10: optional bool enable_compress;
 }
 
 struct TGetSnapshotResult {
@@ -1240,6 +1245,7 @@ struct TGetSnapshotResult {
     2: optional binary meta
     3: optional binary job_info
     4: optional Types.TNetworkAddress master_address
+    5: optional bool compressed;
 }
 
 struct TTableRef {
@@ -1263,6 +1269,7 @@ struct TRestoreSnapshotRequest {
     13: optional bool clean_tables
     14: optional bool clean_partitions
     15: optional bool atomic_restore
+    16: optional bool compressed;
 }
 
 struct TRestoreSnapshotResult {

--- a/pkg/rpc/thrift/HeartbeatService.thrift
+++ b/pkg/rpc/thrift/HeartbeatService.thrift
@@ -41,6 +41,8 @@ struct TMasterInfo {
     9: optional list<TFrontendInfo> frontend_infos
     10: optional string meta_service_endpoint;
     11: optional string cloud_unique_id;
+    // See configuration item Config.java rehash_tablet_after_be_dead_seconds for meaning
+    12: optional i64 tablet_report_inactive_duration_ms;
 }
 
 struct TBackendInfo {

--- a/pkg/rpc/thrift/MasterService.thrift
+++ b/pkg/rpc/thrift/MasterService.thrift
@@ -114,6 +114,8 @@ struct TReportRequest {
     11: i32 num_cores
     12: i32 pipeline_executor_size
     13: optional map<Types.TPartitionId, Types.TVersion> partitions_version
+    // tablet num in be, in cloud num_tablets may not eq tablet_list.size()
+    14: optional i64 num_tablets
 }
 
 struct TMasterResult {

--- a/pkg/rpc/thrift/PaloInternalService.thrift
+++ b/pkg/rpc/thrift/PaloInternalService.thrift
@@ -226,8 +226,8 @@ struct TQueryOptions {
   72: optional bool enable_orc_lazy_mat = true
 
   73: optional i64 scan_queue_mem_limit
-
-  74: optional bool enable_scan_node_run_serial = false; 
+  // deprecated
+  74: optional bool enable_scan_node_run_serial = false;
 
   75: optional bool enable_insert_strict = false;
 
@@ -317,10 +317,11 @@ struct TQueryOptions {
 
   118: optional TSerdeDialect serde_dialect = TSerdeDialect.DORIS;
 
-  119: optional bool keep_carriage_return = false; // \n,\r\n split line in CSV.
+  119: optional bool enable_match_without_inverted_index = true;
 
-  120: optional bool enable_match_without_inverted_index = true;
-  121: optional bool enable_fallback_on_missing_inverted_index = true;
+  120: optional bool enable_fallback_on_missing_inverted_index = true;
+
+  121: optional bool keep_carriage_return = false; // \n,\r\n split line in CSV.
 
   122: optional i32 runtime_bloom_filter_min_size = 1048576;
 
@@ -345,6 +346,12 @@ struct TQueryOptions {
   132: optional i32 parallel_prepare_threshold = 0;
   133: optional i32 partition_topn_max_partitions = 1024;
   134: optional i32 partition_topn_pre_partition_rows = 1000;
+
+  135: optional bool enable_parallel_outfile = false;
+
+  136: optional bool enable_phrase_query_sequential_opt = true;
+
+  137: optional bool enable_auto_create_when_overwrite = false;
   // For cloud, to control if the content would be written into file cache
   // In write path, to control if the content would be written into file cache.
   // In read path, read from file cache or remote storage when execute query.
@@ -368,6 +375,7 @@ struct TRuntimeFilterTargetParamsV2 {
   1: required list<Types.TUniqueId> target_fragment_instance_ids
   // The address of the instance where the fragment is expected to run
   2: required Types.TNetworkAddress target_fragment_instance_addr
+  3: optional list<i32> target_fragment_ids
 }
 
 struct TRuntimeFilterParams {

--- a/pkg/rpc/thrift/PlanNodes.thrift
+++ b/pkg/rpc/thrift/PlanNodes.thrift
@@ -258,6 +258,7 @@ struct TFileTextScanRangeParams {
     4: optional string mapkv_delimiter;
     5: optional i8 enclose;
     6: optional i8 escape;
+    7: optional string null_format;
 }
 
 struct TFileScanSlotInfo {
@@ -308,6 +309,7 @@ struct TIcebergFileDesc {
     // Deprecated
     5: optional Exprs.TExpr file_select_conjunct;
     6: optional string original_file_path;
+    7: optional i64 row_count;
 }
 
 struct TPaimonDeletionFileDesc {
@@ -443,6 +445,8 @@ struct TFileScanRangeParams {
     20: optional list<Exprs.TExpr> pre_filter_exprs_list
     21: optional Types.TUniqueId load_id
     22: optional TTextSerdeType  text_serde_type 
+    // used by flexible partial update
+    23: optional string sequence_map_col
 }
 
 struct TFileRangeDesc {
@@ -538,6 +542,12 @@ struct TPartitionsMetadataParams {
   3: optional string table
 }
 
+struct TPartitionValuesMetadataParams {
+  1: optional string catalog
+  2: optional string database
+  3: optional string table
+}
+
 struct TJobsMetadataParams {
   1: optional string type
   2: optional Types.TUserIdentity current_user_ident
@@ -555,6 +565,7 @@ struct TQueriesMetadataParams {
   4: optional TJobsMetadataParams jobs_params
   5: optional TTasksMetadataParams tasks_params
   6: optional TPartitionsMetadataParams partitions_params
+  7: optional TPartitionValuesMetadataParams partition_values_params
 }
 
 struct TMetaCacheStatsParams {
@@ -571,6 +582,7 @@ struct TMetaScanRange {
   8: optional TTasksMetadataParams tasks_params
   9: optional TPartitionsMetadataParams partitions_params
   10: optional TMetaCacheStatsParams meta_cache_stats_params
+  11: optional TPartitionValuesMetadataParams partition_values_params
 }
 
 // Specification of an individual data range which is held in its entirety
@@ -1354,6 +1366,7 @@ struct TPlanNode {
   49: optional i64 push_down_count
 
   50: optional list<list<Exprs.TExpr>> distribute_expr_lists
+  51: optional bool is_serial_operator
   // projections is final projections, which means projecting into results and materializing them into the output block.
   101: optional list<Exprs.TExpr> projections
   102: optional Types.TTupleId output_tuple_id

--- a/pkg/rpc/thrift/Types.thrift
+++ b/pkg/rpc/thrift/Types.thrift
@@ -419,7 +419,8 @@ enum TOdbcTableType {
     OCEANBASE,
     OCEANBASE_ORACLE,
     NEBULA, // Deprecated
-    DB2
+    DB2,
+    GBASE
 }
 
 struct TJdbcExecutorCtorParams {
@@ -717,6 +718,12 @@ enum TMergeType {
   DELETE
 }
 
+enum TUniqueKeyUpdateMode {
+  UPSERT,
+  UPDATE_FIXED_COLUMNS,
+  UPDATE_FLEXIBLE_COLUMNS
+}
+
 enum TSortType {
     LEXICAL,
     ZORDER,
@@ -732,7 +739,8 @@ enum TMetadataType {
   JOBS,
   TASKS,
   WORKLOAD_SCHED_POLICY,
-  PARTITIONS;
+  PARTITIONS,
+  PARTITION_VALUES;
 }
 
 enum TIcebergQueryType {

--- a/pkg/utils/gzip.go
+++ b/pkg/utils/gzip.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+)
+
+func GZIPDecompress(data []byte) ([]byte, error) {
+	buf := bytes.NewReader(data)
+	reader, err := gzip.NewReader(buf)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	return io.ReadAll(reader)
+}
+
+func GZIPCompress(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	if _, err := writer.Write(data); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/pkg/utils/thrift_wrapper.go
+++ b/pkg/utils/thrift_wrapper.go
@@ -7,7 +7,7 @@ import (
 )
 
 type WrapperType interface {
-	~int64 | ~string
+	~int64 | ~string | ~bool
 }
 
 func ThriftValueWrapper[T WrapperType](value T) *T {
@@ -17,7 +17,7 @@ func ThriftValueWrapper[T WrapperType](value T) *T {
 func ThriftToJsonStr(obj thrift.TStruct) (string, error) {
 	transport := thrift.NewTMemoryBuffer()
 	protocol := thrift.NewTJSONProtocolFactory().GetProtocol(transport)
-	ts := &thrift.TSerializer{transport, protocol}
+	ts := &thrift.TSerializer{Transport: transport, Protocol: protocol}
 	if jsonBytes, err := ts.Write(context.Background(), obj); err != nil {
 		return "", nil
 	} else {


### PR DESCRIPTION
1. Set enable_compress field in GetSnapshot request, to obtain a compressed snapshot meta and job info
2. Check frontend enable_restore_snapshot_rpc_compression config and compress the snapshot meta and job info carried in the RestoreSnapshot request