### PR TITLE
Support txn insert when table sync

### DIFF
--- a/pkg/ccr/ingest_binlog_job.go
+++ b/pkg/ccr/ingest_binlog_job.go
@@ -25,9 +25,20 @@ type commitInfosCollector struct {
 	commitInfosLock sync.Mutex
 }
 
+type subTxnInfosCollector struct {
+	subTxnidToCommitInfos map[int64]([]*ttypes.TTabletCommitInfo)
+	subTxnInfosLock       sync.Mutex
+}
+
 func newCommitInfosCollector() *commitInfosCollector {
 	return &commitInfosCollector{
 		commitInfos: make([]*ttypes.TTabletCommitInfo, 0),
+	}
+}
+
+func newSubTxnInfosCollector() *subTxnInfosCollector {
+	return &subTxnInfosCollector{
+		subTxnidToCommitInfos: make(map[int64]([]*ttypes.TTabletCommitInfo)),
 	}
 }
 
@@ -38,6 +49,23 @@ func (cic *commitInfosCollector) appendCommitInfos(commitInfo ...*ttypes.TTablet
 	cic.commitInfos = append(cic.commitInfos, commitInfo...)
 }
 
+func (stic *subTxnInfosCollector) appendSubTxnCommitInfos(stid int64, commitInfo ...*ttypes.TTabletCommitInfo) {
+	stic.subTxnInfosLock.Lock()
+	defer stic.subTxnInfosLock.Unlock()
+
+	if stic.subTxnidToCommitInfos == nil {
+		stic.subTxnidToCommitInfos = make(map[int64]([]*ttypes.TTabletCommitInfo))
+	}
+
+	tabletCommitInfos := stic.subTxnidToCommitInfos[stid]
+	if tabletCommitInfos == nil {
+		tabletCommitInfos = make([]*ttypes.TTabletCommitInfo, 0)
+	}
+
+	tabletCommitInfos = append(tabletCommitInfos, commitInfo...)
+	stic.subTxnidToCommitInfos[stid] = tabletCommitInfos
+}
+
 func (cic *commitInfosCollector) CommitInfos() []*ttypes.TTabletCommitInfo {
 	cic.commitInfosLock.Lock()
 	defer cic.commitInfosLock.Unlock()
@@ -45,14 +73,24 @@ func (cic *commitInfosCollector) CommitInfos() []*ttypes.TTabletCommitInfo {
 	return cic.commitInfos
 }
 
+func (stic *subTxnInfosCollector) SubTxnToCommitInfos() map[int64]([]*ttypes.TTabletCommitInfo) {
+	stic.subTxnInfosLock.Lock()
+	defer stic.subTxnInfosLock.Unlock()
+
+	return stic.subTxnidToCommitInfos
+}
+
 type tabletIngestBinlogHandler struct {
 	ingestJob       *IngestBinlogJob
 	binlogVersion   int64
+	stid            int64
 	srcTablet       *TabletMeta
 	destTablet      *TabletMeta
 	destPartitionId int64
+	destTableId     int64
 
 	*commitInfosCollector
+	*subTxnInfosCollector
 
 	cancel atomic.Bool
 	wg     sync.WaitGroup
@@ -69,6 +107,7 @@ func (h *tabletIngestBinlogHandler) handleReplica(srcReplica, destReplica *Repli
 	}
 
 	j := h.ingestJob
+	destStid := h.stid
 	binlogVersion := h.binlogVersion
 	srcTablet := h.srcTablet
 	destPartitionId := h.destPartitionId
@@ -94,8 +133,14 @@ func (h *tabletIngestBinlogHandler) handleReplica(srcReplica, destReplica *Repli
 	loadId := ttypes.NewTUniqueId()
 	loadId.SetHi(-1)
 	loadId.SetLo(-1)
+
+	// for txn insert
+	txnId := j.txnId
+	if destStid != 0 {
+		txnId = destStid
+	}
 	req := &bestruct.TIngestBinlogRequest{
-		TxnId:          utils.ThriftValueWrapper(j.txnId),
+		TxnId:          utils.ThriftValueWrapper(txnId),
 		RemoteTabletId: utils.ThriftValueWrapper[int64](srcTablet.Id),
 		BinlogVersion:  utils.ThriftValueWrapper(binlogVersion),
 		RemoteHost:     utils.ThriftValueWrapper(srcBackend.Host),
@@ -138,6 +183,11 @@ func (h *tabletIngestBinlogHandler) handleReplica(srcReplica, destReplica *Repli
 			return
 		} else {
 			h.appendCommitInfos(commitInfo)
+
+			// for txn insert
+			if destStid != 0 {
+				h.appendSubTxnCommitInfos(destStid, commitInfo)
+			}
 		}
 	}()
 
@@ -171,6 +221,11 @@ func (h *tabletIngestBinlogHandler) handle() {
 	h.wg.Wait()
 
 	h.ingestJob.appendCommitInfos(h.CommitInfos()...)
+	// for txn insert
+	if h.stid != 0 {
+		commitInfos := h.SubTxnToCommitInfos()[h.stid]
+		h.ingestJob.appendSubTxnCommitInfos(h.stid, commitInfos...)
+	}
 }
 
 type IngestContext struct {
@@ -178,6 +233,7 @@ type IngestContext struct {
 	txnId        int64
 	tableRecords []*record.TableRecord
 	tableMapping map[int64]int64
+	stidMapping  map[int64]int64
 }
 
 func NewIngestContext(txnId int64, tableRecords []*record.TableRecord, tableMapping map[int64]int64) *IngestContext {
@@ -189,6 +245,17 @@ func NewIngestContext(txnId int64, tableRecords []*record.TableRecord, tableMapp
 	}
 }
 
+func NewIngestContextForTxnInsert(txnId int64, tableRecords []*record.TableRecord,
+	tableMapping map[int64]int64, stidMapping map[int64]int64) *IngestContext {
+	return &IngestContext{
+		Context:      context.Background(),
+		txnId:        txnId,
+		tableRecords: tableRecords,
+		tableMapping: tableMapping,
+		stidMapping:  stidMapping,
+	}
+}
+
 type IngestBinlogJob struct {
 	ccrJob  *Job // ccr job
 	factory *Factory
@@ -196,6 +263,7 @@ type IngestBinlogJob struct {
 	tableMapping map[int64]int64
 	srcMeta      IngestBinlogMetaer
 	destMeta     IngestBinlogMetaer
+	stidMap      map[int64]int64
 
 	txnId        int64
 	tableRecords []*record.TableRecord
@@ -206,6 +274,7 @@ type IngestBinlogJob struct {
 	tabletIngestJobs []*tabletIngestBinlogHandler
 
 	*commitInfosCollector
+	*subTxnInfosCollector
 
 	err     error
 	errLock sync.RWMutex
@@ -227,8 +296,10 @@ func NewIngestBinlogJob(ctx context.Context, ccrJob *Job) (*IngestBinlogJob, err
 		tableMapping: ingestCtx.tableMapping,
 		txnId:        ingestCtx.txnId,
 		tableRecords: ingestCtx.tableRecords,
+		stidMap:      ingestCtx.stidMapping,
 
 		commitInfosCollector: newCommitInfosCollector(),
+		subTxnInfosCollector: newSubTxnInfosCollector(),
 	}, nil
 }
 
@@ -269,6 +340,7 @@ func (j *IngestBinlogJob) Error() error {
 type prepareIndexArg struct {
 	binlogVersion   int64
 	srcTableId      int64
+	stid            int64
 	srcPartitionId  int64
 	destTableId     int64
 	destPartitionId int64
@@ -321,12 +393,15 @@ func (j *IngestBinlogJob) prepareIndex(arg *prepareIndexArg) {
 		destTablet := destIter.Value()
 		tabletIngestBinlogHandler := &tabletIngestBinlogHandler{
 			ingestJob:       j,
+			stid:            arg.stid,
 			binlogVersion:   arg.binlogVersion,
 			srcTablet:       srcTablet,
 			destTablet:      destTablet,
 			destPartitionId: arg.destPartitionId,
+			destTableId:     arg.destTableId,
 
 			commitInfosCollector: newCommitInfosCollector(),
+			subTxnInfosCollector: newSubTxnInfosCollector(),
 		}
 		j.tabletIngestJobs = append(j.tabletIngestJobs, tabletIngestBinlogHandler)
 
@@ -354,6 +429,8 @@ func (j *IngestBinlogJob) preparePartition(srcTableId, destTableId int64, partit
 
 	srcPartitionId := partitionRecord.Id
 	srcPartitionRange := partitionRecord.Range
+	sourceStid := partitionRecord.Stid
+	stidMap := j.stidMap
 	destPartitionId, err := j.destMeta.GetPartitionIdByRange(destTableId, srcPartitionRange)
 	if err != nil {
 		j.setError(err)
@@ -407,6 +484,7 @@ func (j *IngestBinlogJob) preparePartition(srcTableId, destTableId int64, partit
 	prepareIndexArg := prepareIndexArg{
 		binlogVersion:   partitionRecord.Version,
 		srcTableId:      srcTableId,
+		stid:            stidMap[sourceStid],
 		srcPartitionId:  srcPartitionId,
 		destTableId:     destTableId,
 		destPartitionId: destPartitionId,

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -1278,6 +1278,47 @@ func (j *Job) ingestBinlog(txnId int64, tableRecords []*record.TableRecord) ([]*
 	return ingestBinlogJob.CommitInfos(), nil
 }
 
+// Table ingestBinlog for txn insert
+func (j *Job) ingestBinlogForTxnInsert(txnId int64, tableRecords []*record.TableRecord, stidMap map[int64]int64, destTableId int64) ([]*festruct.TSubTxnInfo, error) {
+	log.Infof("ingestBinlogForTxnInsert, txnId: %d", txnId)
+
+	job, err := j.jobFactory.CreateJob(NewIngestContextForTxnInsert(txnId, tableRecords, j.progress.TableMapping, stidMap), j, "IngestBinlog")
+	if err != nil {
+		return nil, err
+	}
+
+	ingestBinlogJob, ok := job.(*IngestBinlogJob)
+	if !ok {
+		return nil, xerror.Errorf(xerror.Normal, "invalid job type, job: %+v", job)
+	}
+
+	job.Run()
+	if err := job.Error(); err != nil {
+		return nil, err
+	}
+
+	stidToCommitInfos := ingestBinlogJob.SubTxnToCommitInfos()
+	subTxnInfos := make([]*festruct.TSubTxnInfo, 0, len(stidMap))
+	for sourceStid, destStid := range stidMap {
+		destStid := destStid // if no this line, every element in subTxnInfos is the last tSubTxnInfo
+		commitInfos := stidToCommitInfos[destStid]
+		if commitInfos == nil {
+			log.Warnf("no commit infos from source stid: %d; dest stid %d, just skip", sourceStid, destStid)
+			continue
+		}
+
+		tSubTxnInfo := &festruct.TSubTxnInfo{
+			SubTxnId:          &destStid,
+			TableId:           &destTableId,
+			TabletCommitInfos: commitInfos,
+		}
+
+		subTxnInfos = append(subTxnInfos, tSubTxnInfo)
+	}
+
+	return subTxnInfos, nil
+}
+
 func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 	log.Infof("handle upsert binlog, sub sync state: %s, prevCommitSeq: %d, commitSeq: %d",
 		j.progress.SubSyncState, j.progress.PrevCommitSeq, j.progress.CommitSeq)
@@ -1289,6 +1330,10 @@ func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 		DestTableIds []int64                     `json:"dest_table_ids"`
 		TableRecords []*record.TableRecord       `json:"table_records"`
 		CommitInfos  []*ttypes.TTabletCommitInfo `json:"commit_infos"`
+		IsTxnInsert  bool                        `json:"is_txn_insert"`
+		SourceStids  []int64                     `json:"source_stid"`
+		DestStids    []int64                     `json:"desc_stid"`
+		SubTxnInfos  []*festruct.TSubTxnInfo     `json:"sub_txn_infos"`
 	}
 
 	updateInMemory := func() error {
@@ -1347,6 +1392,15 @@ func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 		log.Debugf("upsert: %v", upsert)
 
 		// Step 1: get related tableRecords
+		var isTxnInsert bool = false
+		if len(upsert.Stids) > 0 {
+			if j.SyncType == DBSync {
+				log.Warnf("Txn insert is NOT supported when DBSync")
+				return xerror.Errorf(xerror.Normal, "Txn insert is NOT supported when DBSync")
+			}
+			isTxnInsert = true
+		}
+
 		tableRecords, err := j.getReleatedTableRecords(upsert)
 		if err != nil {
 			log.Errorf("get related table records failed, err: %+v", err)
@@ -1373,6 +1427,8 @@ func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 			CommitSeq:    upsert.CommitSeq,
 			DestTableIds: destTableIds,
 			TableRecords: tableRecords,
+			IsTxnInsert:  isTxnInsert,
+			SourceStids:  upsert.Stids,
 		}
 		j.progress.NextSubVolatile(BeginTransaction, inMemoryData)
 
@@ -1380,6 +1436,8 @@ func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 		// Step 2: begin txn
 		inMemoryData := j.progress.InMemoryData.(*inMemoryData)
 		commitSeq := inMemoryData.CommitSeq
+		sourceStids := inMemoryData.SourceStids
+		isTxnInsert := inMemoryData.IsTxnInsert
 		log.Debugf("begin txn, dest: %v, commitSeq: %d", dest, commitSeq)
 
 		destRpc, err := j.factory.NewFeRpc(dest)
@@ -1389,7 +1447,14 @@ func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 
 		label := j.newLabel(commitSeq)
 
-		beginTxnResp, err := destRpc.BeginTransaction(dest, label, inMemoryData.DestTableIds)
+		var beginTxnResp *festruct.TBeginTxnResult_
+		if isTxnInsert {
+			// when txn insert, give an array length in BeginTransaction, it will return a list of stid
+			beginTxnResp, err = destRpc.BeginTransactionForTxnInsert(dest, label, inMemoryData.DestTableIds, int64(len(sourceStids)))
+		} else {
+			beginTxnResp, err = destRpc.BeginTransaction(dest, label, inMemoryData.DestTableIds)
+		}
+
 		if err != nil {
 			return err
 		}
@@ -1406,7 +1471,13 @@ func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 			return xerror.Errorf(xerror.Normal, "begin txn failed, status: %v", beginTxnResp.GetStatus())
 		}
 		txnId := beginTxnResp.GetTxnId()
-		log.Debugf("TxnId: %d, DbId: %d", txnId, beginTxnResp.GetDbId())
+		if isTxnInsert {
+			destStids := beginTxnResp.GetSubTxnIds()
+			inMemoryData.DestStids = destStids
+			log.Debugf("TxnId: %d, DbId: %d, destStids: %v", txnId, beginTxnResp.GetDbId(), destStids)
+		} else {
+			log.Debugf("TxnId: %d, DbId: %d", txnId, beginTxnResp.GetDbId())
+		}
 
 		inMemoryData.TxnId = txnId
 		j.progress.NextSubCheckpoint(IngestBinlog, inMemoryData)
@@ -1419,17 +1490,43 @@ func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 		inMemoryData := j.progress.InMemoryData.(*inMemoryData)
 		tableRecords := inMemoryData.TableRecords
 		txnId := inMemoryData.TxnId
+		isTxnInsert := inMemoryData.IsTxnInsert
+
+		// make stidMap, source_stid to dest_stid
+		stidMap := make(map[int64]int64)
+		if isTxnInsert {
+			sourceStids := inMemoryData.SourceStids
+			destStids := inMemoryData.DestStids
+			if len(sourceStids) == len(destStids) {
+				for i := 0; i < len(sourceStids); i++ {
+					stidMap[sourceStids[i]] = destStids[i]
+				}
+			}
+		}
 
 		// Step 3: ingest binlog
-		var commitInfos []*ttypes.TTabletCommitInfo
-		commitInfos, err := j.ingestBinlog(txnId, tableRecords)
-		if err != nil {
-			rollback(err, inMemoryData)
-			return err
+		if isTxnInsert {
+			// When txn insert, only one table can be inserted, so use the first DestTableId
+			destTableId := inMemoryData.DestTableIds[0]
+
+			// When txn insert, use subTxnInfos to commit rather than commitInfos.
+			subTxnInfos, err := j.ingestBinlogForTxnInsert(txnId, tableRecords, stidMap, destTableId)
+			if err != nil {
+				rollback(err, inMemoryData)
+				return err
+			} else {
+				inMemoryData.SubTxnInfos = subTxnInfos
+				j.progress.NextSubCheckpoint(CommitTransaction, inMemoryData)
+			}
 		} else {
-			log.Debugf("commitInfos: %v", commitInfos)
-			inMemoryData.CommitInfos = commitInfos
-			j.progress.NextSubCheckpoint(CommitTransaction, inMemoryData)
+			commitInfos, err := j.ingestBinlog(txnId, tableRecords)
+			if err != nil {
+				rollback(err, inMemoryData)
+				return err
+			} else {
+				inMemoryData.CommitInfos = commitInfos
+				j.progress.NextSubCheckpoint(CommitTransaction, inMemoryData)
+			}
 		}
 
 	case CommitTransaction:
@@ -1448,7 +1545,14 @@ func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 			break
 		}
 
-		resp, err := destRpc.CommitTransaction(dest, txnId, commitInfos)
+		isTxnInsert := inMemoryData.IsTxnInsert
+		subTxnInfos := inMemoryData.SubTxnInfos
+		var resp *festruct.TCommitTxnResult_
+		if isTxnInsert {
+			resp, err = destRpc.CommitTransactionForTxnInsert(dest, txnId, true, subTxnInfos)
+		} else {
+			resp, err = destRpc.CommitTransaction(dest, txnId, commitInfos)
+		}
 		if err != nil {
 			rollback(err, inMemoryData)
 			break

--- a/pkg/ccr/record/upsert.go
+++ b/pkg/ccr/record/upsert.go
@@ -12,6 +12,7 @@ type PartitionRecord struct {
 	Range   string `json:"range"`
 	Version int64  `json:"version"`
 	IsTemp  bool   `json:"isTempPartition"`
+	Stid    int64  `json:stid`
 }
 
 func (p PartitionRecord) String() string {
@@ -35,11 +36,12 @@ type Upsert struct {
 	Label        string                 `json:"label"`
 	DbID         int64                  `json:"dbId"`
 	TableRecords map[int64]*TableRecord `json:"tableRecords"`
+	Stids        []int64                `json:"stids"`
 }
 
 // Stringer
 func (u Upsert) String() string {
-	return fmt.Sprintf("Upsert{CommitSeq: %d, TxnID: %d, TimeStamp: %d, Label: %s, DbID: %d, TableRecords: %v}", u.CommitSeq, u.TxnID, u.TimeStamp, u.Label, u.DbID, u.TableRecords)
+	return fmt.Sprintf("Upsert{CommitSeq: %d, TxnID: %d, TimeStamp: %d, Label: %s, DbID: %d, TableRecords: %v, Stids: %v}", u.CommitSeq, u.TxnID, u.TimeStamp, u.Label, u.DbID, u.TableRecords, u.Stids)
 }
 
 //	{

--- a/pkg/rpc/fe.go
+++ b/pkg/rpc/fe.go
@@ -83,7 +83,9 @@ type RestoreSnapshotRequest struct {
 
 type IFeRpc interface {
 	BeginTransaction(*base.Spec, string, []int64) (*festruct.TBeginTxnResult_, error)
+	BeginTransactionForTxnInsert(*base.Spec, string, []int64, int64) (*festruct.TBeginTxnResult_, error)
 	CommitTransaction(*base.Spec, int64, []*festruct_types.TTabletCommitInfo) (*festruct.TCommitTxnResult_, error)
+	CommitTransactionForTxnInsert(*base.Spec, int64, bool, []*festruct.TSubTxnInfo) (*festruct.TCommitTxnResult_, error)
 	RollbackTransaction(spec *base.Spec, txnId int64) (*festruct.TRollbackTxnResult_, error)
 	GetBinlog(*base.Spec, int64) (*festruct.TGetBinlogResult_, error)
 	GetBinlogLag(*base.Spec, int64) (*festruct.TGetBinlogLagResult_, error)
@@ -349,10 +351,28 @@ func (rpc *FeRpc) BeginTransaction(spec *base.Spec, label string, tableIds []int
 	return convertResult[festruct.TBeginTxnResult_](result, err)
 }
 
+func (rpc *FeRpc) BeginTransactionForTxnInsert(spec *base.Spec, label string, tableIds []int64, stidNum int64) (*festruct.TBeginTxnResult_, error) {
+	// return rpc.masterClient.BeginTransactionForTxnInsert(spec, label, tableIds, stidNum)
+	caller := func(client IFeRpc) (resultType, error) {
+		return client.BeginTransactionForTxnInsert(spec, label, tableIds, stidNum)
+	}
+	result, err := rpc.callWithMasterRedirect(caller)
+	return convertResult[festruct.TBeginTxnResult_](result, err)
+}
+
 func (rpc *FeRpc) CommitTransaction(spec *base.Spec, txnId int64, commitInfos []*festruct_types.TTabletCommitInfo) (*festruct.TCommitTxnResult_, error) {
 	// return rpc.masterClient.CommitTransaction(spec, txnId, commitInfos)
 	caller := func(client IFeRpc) (resultType, error) {
 		return client.CommitTransaction(spec, txnId, commitInfos)
+	}
+	result, err := rpc.callWithMasterRedirect(caller)
+	return convertResult[festruct.TCommitTxnResult_](result, err)
+}
+
+func (rpc *FeRpc) CommitTransactionForTxnInsert(spec *base.Spec, txnId int64, isTxnInsert bool, subTxnInfos []*festruct.TSubTxnInfo) (*festruct.TCommitTxnResult_, error) {
+	// return rpc.masterClient.CommitTransactionForTxnInsert(spec, txnId, commitInfos, subTxnInfos)
+	caller := func(client IFeRpc) (resultType, error) {
+		return client.CommitTransactionForTxnInsert(spec, txnId, isTxnInsert, subTxnInfos)
 	}
 	result, err := rpc.callWithMasterRedirect(caller)
 	return convertResult[festruct.TCommitTxnResult_](result, err)
@@ -504,6 +524,25 @@ func (rpc *singleFeClient) BeginTransaction(spec *base.Spec, label string, table
 	}
 }
 
+func (rpc *singleFeClient) BeginTransactionForTxnInsert(spec *base.Spec, label string, tableIds []int64, stidNum int64) (*festruct.TBeginTxnResult_, error) {
+	log.Debugf("Call BeginTransactionForTxnInsert, addr: %s, spec: %s, label: %s, tableIds: %v", rpc.Address(), spec, label, tableIds)
+
+	client := rpc.client
+	req := &festruct.TBeginTxnRequest{
+		Label: &label,
+	}
+	setAuthInfo(req, spec)
+	req.TableIds = tableIds
+	req.SubTxnNum = stidNum
+
+	log.Debugf("BeginTransactionForTxnInsert user %s, label: %s, tableIds: %v", req.GetUser(), label, tableIds)
+	if result, err := client.BeginTxn(context.Background(), req); err != nil {
+		return nil, xerror.Wrapf(err, xerror.RPC, "BeginTransactionForTxnInsert error: %v, req: %+v", err, req)
+	} else {
+		return result, nil
+	}
+}
+
 //	struct TCommitTxnRequest {
 //	    1: optional string cluster
 //	    2: required string user
@@ -529,6 +568,23 @@ func (rpc *singleFeClient) CommitTransaction(spec *base.Spec, txnId int64, commi
 
 	if result, err := client.CommitTxn(context.Background(), req, callopt.WithRPCTimeout(commitTxnTimeout)); err != nil {
 		return nil, xerror.Wrapf(err, xerror.RPC, "CommitTransaction error: %v, req: %+v", err, req)
+	} else {
+		return result, nil
+	}
+}
+
+func (rpc *singleFeClient) CommitTransactionForTxnInsert(spec *base.Spec, txnId int64, isTxnInsert bool, subTxnInfos []*festruct.TSubTxnInfo) (*festruct.TCommitTxnResult_, error) {
+	log.Debugf("Call CommitTransactionForTxnInsert, addr: %s spec: %s, txnId: %d, subTxnInfos: %v", rpc.Address(), spec, txnId, subTxnInfos)
+
+	client := rpc.client
+	req := &festruct.TCommitTxnRequest{}
+	setAuthInfo(req, spec)
+	req.TxnId = &txnId
+	req.TxnInsert = &isTxnInsert
+	req.SubTxnInfos = subTxnInfos
+
+	if result, err := client.CommitTxn(context.Background(), req, callopt.WithRPCTimeout(commitTxnTimeout)); err != nil {
+		return nil, xerror.Wrapf(err, xerror.RPC, "CommitTransactionForTxnInsert error: %v, req: %+v", err, req)
 	} else {
 		return result, nil
 	}
@@ -780,6 +836,7 @@ func (rpc *singleFeClient) GetTableMeta(spec *base.Spec, tableIds []int64) (*fes
 
 	reqTables := make([]*festruct.TGetMetaTable, 0, len(tableIds))
 	for _, tableId := range tableIds {
+		tableId := tableId
 		reqTable := festruct.NewTGetMetaTable()
 		reqTable.Id = &tableId
 		reqTables = append(reqTables, reqTable)

--- a/regression-test/suites/table_sync/table/txn_insert/test_txn_insert.groovy
+++ b/regression-test/suites/table_sync/table/txn_insert/test_txn_insert.groovy
@@ -1,0 +1,129 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_txn_insert") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    def tableName1 = "t1_" + helper.randomSuffix()
+    def tableName2 = "t2_" + helper.randomSuffix()
+    def test_num = 0
+    def insert_num = 10
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+    def notExist = { res -> Boolean
+        return res.size() == 0
+    }
+
+    def hasRollupFull = { res -> Boolean
+        for (List<Object> row : res) {
+            if ((row[0] as String) == "${new_rollup_name}") {
+                return true
+            }
+        }
+        return false
+    }
+
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName1}
+        (
+          `user_id` LARGEINT NOT NULL COMMENT "用户id",
+          `date` DATE NOT NULL COMMENT "数据灌入日期时间",
+          `city` VARCHAR(20) COMMENT "用户所在城市"
+        ) ENGINE = olap
+        unique KEY(`user_id`, `date`)
+        PARTITION BY RANGE (`date`)
+        (
+            PARTITION `p201701` VALUES LESS THAN ("2017-02-01"),
+            PARTITION `p201702` VALUES LESS THAN ("2017-03-01"),
+            PARTITION `p201703` VALUES LESS THAN ("2017-04-01")
+        )
+        DISTRIBUTED BY HASH(`user_id`) BUCKETS 1
+        PROPERTIES ("replication_num" = "1", "binlog.enable" = "true","enable_unique_key_merge_on_write" = "false");
+    """
+
+    sql """
+    CREATE TABLE IF NOT EXISTS ${tableName2} (`id` int)
+       ENGINE = olap unique KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 2
+        PROPERTIES
+        ("replication_allocation" = "tag.location.default: 1", "binlog.enable" = "true", "enable_unique_key_merge_on_write" = "false");
+    """
+
+    sql """ insert into ${tableName2} values (3),(4),(5); """
+    sql """ insert into ${tableName1} values (1, '2017-03-31', 'a'), (2, '2017-02-28', 'b'); """
+
+    helper.ccrJobDelete(tableName1)
+    helper.ccrJobCreate(tableName1)
+
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName1}", 60))
+
+
+    logger.info("=== Test 0: Table sync ===")
+    sql "sync"
+    assertTrue(helper.checkShowTimesOf("SELECT * FROM ${tableName1} ", exist, 60, "target"))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", 2, 30))
+
+
+    logger.info("=== Test 1: insert only ===")
+    sql """ 
+        begin; 
+        insert into ${tableName1}  select id, '2017-02-28', 'y1' from ${tableName2} where id = 3;
+        insert into ${tableName1}  select id, '2017-02-28', 'y1' from ${tableName2} where id = 5;
+        insert into ${tableName1}  select id, '2017-03-31', 'x' from ${tableName2} where id = 4;
+        commit;
+        """
+    assertTrue(helper.checkShowTimesOf("SELECT * FROM ${tableName1} ", exist, 60, "target"))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1} ", 5, 30))
+
+
+    logger.info("=== Test 2: insert + update ===")
+    sql """
+        begin;
+        update ${tableName1} set city = 'xxx' where user_id = 3; 
+        insert into ${tableName1} select id + 1, '2017-02-28', 'yyy' from ${tableName2} where id = 5;
+        commit;
+    """
+    assertTrue(helper.checkShowTimesOf("SELECT * FROM ${tableName1} ", exist, 60, "target"))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1} where city = 'xxx' or user_id = 6", 2, 30))
+
+
+    logger.info("=== Test 3: insert + delete ===")
+    sql """
+        begin;
+        delete from ${tableName1} PARTITION p201702 where user_id = 5;
+        insert into ${tableName1} select id, '2017-02-28', 'new_y1' from ${tableName2} where id = 5;
+        commit;
+    """
+    assertTrue(helper.checkShowTimesOf("SELECT * FROM ${tableName1} ", exist, 60, "target"))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1} where city = 'new_y1'", 1, 30))
+
+
+    logger.info("=== Test 4: insert + update + delete ===")
+    sql """
+        begin;
+        delete from ${tableName1} PARTITION p201702 where user_id = 6;
+        insert into ${tableName1} select id + 2, '2017-02-28', 'y1' from ${tableName2} where id = 5;
+        update ${tableName1} set city = 'new_city' where user_id = 5; 
+        commit;
+    """
+    assertTrue(helper.checkShowTimesOf("SELECT * FROM ${tableName1} ", exist, 60, "target"))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1} where city = 'new_city' and user_id = 5", 1, 30))
+}
+


### PR DESCRIPTION
Txn insert is the SQL which starts with 'BEGIN' and ends with 'COMMIT/ROLLBACK'. 

The general SQL may be like this :

## insert 
```
        begin; 
        insert into t1  select id, '2017-02-28', 'y1' from t2 where id = 3;
        insert into t1  select id, '2017-02-28', 'y1' from t2 where id = 5;
        insert into t1  select id, '2017-03-31', 'x' from t2 where id = 4;
        commit;
```
## update + insert
```
        begin;
        update t1 set city = 'xxx' where user_id = 3; 
        insert into t1 select id + 1, '2017-02-28', 'yyy' from t2 where id = 5;
        commit;
```
## delete + insert
```
        begin;
        delete from t1 PARTITION p201702 where user_id = 5;
        insert into t1 select id, '2017-02-28', 'new_y1' from t2 where id = 5;
        commit;
```
## insert + update + delete
```
        begin;
        delete from t1 PARTITION p201702 where user_id = 6;
        insert into t1 select id + 2, '2017-02-28', 'y1' from t2 where id = 5;
        update t1 set city = 'new_city' where user_id = 5; 
        commit;
```


DB sync will support later.