### PR TITLE
Fix wrong table name dependencies

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -350,6 +350,7 @@ func (j *Job) partialSync() error {
 		SnapshotName      string                        `json:"snapshot_name"`
 		SnapshotResp      *festruct.TGetSnapshotResult_ `json:"snapshot_resp"`
 		TableCommitSeqMap map[int64]int64               `json:"table_commit_seq_map"`
+		TableNameMapping  map[int64]string              `json:"table_name_mapping"`
 		RestoreLabel      string                        `json:"restore_label"`
 	}
 
@@ -386,6 +387,9 @@ func (j *Job) partialSync() error {
 
 		snapshotName := NewLabelWithTs(prefix)
 		if err := j.ISrc.CreatePartialSnapshot(snapshotName, table, partitions); err != nil {
+			// TODO: handle error
+			// 1. Unknown partition p2 in tabletbl_replace_partition_687615531
+			// 2. Unknown table 'tbl_old_1508939100'
 			return err
 		}
 
@@ -450,18 +454,19 @@ func (j *Job) partialSync() error {
 		}
 
 		tableCommitSeqMap := backupJobInfo.TableCommitSeqMap
-
-		log.Debugf("table commit seq map: %v", tableCommitSeqMap)
-		if j.SyncType == TableSync {
-			if _, ok := tableCommitSeqMap[j.Src.TableId]; !ok {
-				return xerror.Errorf(xerror.Normal, "table id %d, commit seq not found", j.Src.TableId)
-			}
+		tableNameMapping := backupJobInfo.TableNameMapping()
+		log.Debugf("table commit seq map: %v, table name mapping: %v", tableCommitSeqMap, tableNameMapping)
+		if backupObject, ok := backupJobInfo.BackupObjects[table]; !ok {
+			return xerror.Errorf(xerror.Normal, "table %s not found in backup objects", table)
+		} else if _, ok := tableCommitSeqMap[backupObject.Id]; !ok {
+			return xerror.Errorf(xerror.Normal, "commit seq not found, table id %d, table name: %s", backupObject.Id, table)
 		}
 
 		inMemoryData := &inMemoryData{
 			SnapshotName:      snapshotName,
 			SnapshotResp:      snapshotResp,
 			TableCommitSeqMap: tableCommitSeqMap,
+			TableNameMapping:  tableNameMapping,
 		}
 		j.progress.NextSubVolatile(AddExtraInfo, inMemoryData)
 
@@ -598,12 +603,10 @@ func (j *Job) partialSync() error {
 		}
 
 		// save the entire commit seq map, this value will be used in PersistRestoreInfo.
-		if len(j.progress.TableCommitSeqMap) == 0 {
-			j.progress.TableCommitSeqMap = make(map[int64]int64)
-		}
-		for tableId, commitSeq := range inMemoryData.TableCommitSeqMap {
-			j.progress.TableCommitSeqMap[tableId] = commitSeq
-		}
+		j.progress.TableCommitSeqMap = utils.MergeMap(
+			j.progress.TableCommitSeqMap, inMemoryData.TableCommitSeqMap)
+		j.progress.TableNameMapping = utils.MergeMap(
+			j.progress.TableNameMapping, inMemoryData.TableNameMapping)
 		j.progress.NextSubCheckpoint(PersistRestoreInfo, restoreSnapshotName)
 
 	case PersistRestoreInfo:
@@ -642,9 +645,14 @@ func (j *Job) partialSync() error {
 		}
 		switch j.SyncType {
 		case DBSync:
-			srcTableId, err := j.srcMeta.GetTableId(table)
-			if err != nil {
-				return err
+			srcTableId, ok := j.progress.GetTableId(table)
+			if !ok {
+				// Keep compatible with the old version, try to get the table id from the FE.
+				// The result might be wrong since the table might has been changed, eg: rename, replace.
+				srcTableId, err = j.srcMeta.GetTableId(table)
+				if err != nil {
+					return xerror.Wrapf(err, xerror.Meta, "table id is not found in table name mapping, table %s", table)
+				}
 			}
 			j.progress.TableMapping[srcTableId] = destTable.Id
 			j.progress.NextWithPersist(j.progress.CommitSeq, DBTablesIncrementalSync, Done, "")
@@ -1175,12 +1183,14 @@ func (j *Job) getDestTableIdBySrc(srcTableId int64) (int64, error) {
 		if destTableId, ok := j.progress.TableMapping[srcTableId]; ok {
 			return destTableId, nil
 		}
-		log.Warnf("table mapping not found, srcTableId: %d", srcTableId)
+		log.Warnf("table mapping not found, src table id: %d", srcTableId)
 	} else {
-		log.Warnf("table mapping not found, srcTableId: %d", srcTableId)
+		log.Warnf("table mapping not found, src table id: %d", srcTableId)
 		j.progress.TableMapping = make(map[int64]int64)
 	}
 
+	// WARNING: the table name might be changed, and the TableMapping has been updated in time,
+	// only keep this for compatible.
 	srcTableName, err := j.srcMeta.GetTableNameById(srcTableId)
 	if err != nil {
 		return 0, err
@@ -1625,22 +1635,16 @@ func (j *Job) handleCreateTable(binlog *festruct.TBinlog) error {
 	j.srcMeta.ClearTablesCache()
 	j.destMeta.ClearTablesCache()
 
-	var srcTableName string
-	srcTableName, err = j.srcMeta.GetTableNameById(createTable.TableId)
-	if err != nil {
-		return err
-	}
-
+	srcTableName := createTable.TableName
 	if len(srcTableName) == 0 {
-		// The table is not found in upstream, try read it from the binlog record,
-		// but it might failed because the `tableName` field is added after doris 2.0.3.
-		srcTableName = strings.TrimSpace(createTable.TableName)
-		if len(srcTableName) == 0 {
+		// the field `TableName` is added after doris 2.0.3, to keep compatible, try read src table
+		// name from upstream, but the result might be wrong if upstream has executed rename/replace.
+		log.Infof("the table id %d is not found in the binlog record, get the name from the upstream", createTable.TableId)
+		srcTableName, err = j.srcMeta.GetTableNameById(createTable.TableId)
+        if err != nil {
 			return xerror.Errorf(xerror.Normal, "the table with id %d is not found in the upstream cluster, create table: %s",
 				createTable.TableId, createTable.String())
-		}
-		log.Infof("the table id %d is not found in the upstream, use the name %s from the binlog record",
-			createTable.TableId, srcTableName)
+        }
 	}
 
 	var destTableId int64
@@ -1653,6 +1657,10 @@ func (j *Job) handleCreateTable(binlog *festruct.TBinlog) error {
 		j.progress.TableMapping = make(map[int64]int64)
 	}
 	j.progress.TableMapping[createTable.TableId] = destTableId
+    if j.progress.TableNameMapping == nil {
+        j.progress.TableNameMapping = make(map[int64]string)
+    }
+    j.progress.TableNameMapping[createTable.TableId] = srcTableName
 	j.progress.Done()
 	return nil
 }
@@ -1673,7 +1681,7 @@ func (j *Job) handleDropTable(binlog *festruct.TBinlog) error {
 	}
 
 	tableName := dropTable.TableName
-	// deprecated
+	// deprecated, `TableName` has been added after doris 2.0.0
 	if tableName == "" {
 		dirtySrcTables := j.srcMeta.DirtyGetTables()
 		srcTable, ok := dirtySrcTables[dropTable.TableId]
@@ -1697,10 +1705,8 @@ func (j *Job) handleDropTable(binlog *festruct.TBinlog) error {
 
 	j.srcMeta.ClearTablesCache()
 	j.destMeta.ClearTablesCache()
-	if j.progress.TableMapping != nil {
-		delete(j.progress.TableMapping, dropTable.TableId)
-		j.progress.Done()
-	}
+    delete(j.progress.TableNameMapping, dropTable.TableId)
+	delete(j.progress.TableMapping, dropTable.TableId)
 	return nil
 }
 
@@ -1910,10 +1916,7 @@ func (j *Job) handleTruncateTable(binlog *festruct.TBinlog) error {
 
 	err = j.IDest.TruncateTable(destTableName, truncateTable)
 	if err == nil {
-		if srcTableName, err := j.srcMeta.GetTableNameById(truncateTable.TableId); err == nil {
-			// if err != nil, maybe truncate table had been dropped
-			j.srcMeta.ClearTable(j.Src.Database, srcTableName)
-		}
+        j.srcMeta.ClearTable(j.Src.Database, truncateTable.TableName)
 		j.destMeta.ClearTable(j.Dest.Database, destTableName)
 	}
 
@@ -1980,8 +1983,6 @@ func (j *Job) handleRenameTable(binlog *festruct.TBinlog) error {
 }
 
 func (j *Job) handleRenameTableRecord(renameTable *record.RenameTable) error {
-	j.srcMeta.GetTables()
-
 	// don't support rename table when table sync
 	if j.SyncType == TableSync {
 		log.Warnf("rename table is not supported when table sync, consider rebuilding this job instead")
@@ -2009,11 +2010,17 @@ func (j *Job) handleRenameTableRecord(renameTable *record.RenameTable) error {
 	}
 
 	err = j.IDest.RenameTable(destTableName, renameTable)
-	if err == nil {
-		j.destMeta.GetTables()
-	}
+    if err != nil {
+        return err
+    }
 
-	return err
+    j.destMeta.GetTables()
+    if j.progress.TableNameMapping == nil {
+        j.progress.TableNameMapping = make(map[int64]string)
+    }
+    j.progress.TableNameMapping[renameTable.TableId] = renameTable.NewTableName
+
+	return nil
 }
 
 func (j *Job) handleBarrier(binlog *festruct.TBinlog) error {

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -1641,10 +1641,10 @@ func (j *Job) handleCreateTable(binlog *festruct.TBinlog) error {
 		// name from upstream, but the result might be wrong if upstream has executed rename/replace.
 		log.Infof("the table id %d is not found in the binlog record, get the name from the upstream", createTable.TableId)
 		srcTableName, err = j.srcMeta.GetTableNameById(createTable.TableId)
-        if err != nil {
+		if err != nil {
 			return xerror.Errorf(xerror.Normal, "the table with id %d is not found in the upstream cluster, create table: %s",
 				createTable.TableId, createTable.String())
-        }
+		}
 	}
 
 	var destTableId int64
@@ -1657,10 +1657,10 @@ func (j *Job) handleCreateTable(binlog *festruct.TBinlog) error {
 		j.progress.TableMapping = make(map[int64]int64)
 	}
 	j.progress.TableMapping[createTable.TableId] = destTableId
-    if j.progress.TableNameMapping == nil {
-        j.progress.TableNameMapping = make(map[int64]string)
-    }
-    j.progress.TableNameMapping[createTable.TableId] = srcTableName
+	if j.progress.TableNameMapping == nil {
+		j.progress.TableNameMapping = make(map[int64]string)
+	}
+	j.progress.TableNameMapping[createTable.TableId] = srcTableName
 	j.progress.Done()
 	return nil
 }
@@ -1705,7 +1705,7 @@ func (j *Job) handleDropTable(binlog *festruct.TBinlog) error {
 
 	j.srcMeta.ClearTablesCache()
 	j.destMeta.ClearTablesCache()
-    delete(j.progress.TableNameMapping, dropTable.TableId)
+	delete(j.progress.TableNameMapping, dropTable.TableId)
 	delete(j.progress.TableMapping, dropTable.TableId)
 	return nil
 }
@@ -1916,7 +1916,7 @@ func (j *Job) handleTruncateTable(binlog *festruct.TBinlog) error {
 
 	err = j.IDest.TruncateTable(destTableName, truncateTable)
 	if err == nil {
-        j.srcMeta.ClearTable(j.Src.Database, truncateTable.TableName)
+		j.srcMeta.ClearTable(j.Src.Database, truncateTable.TableName)
 		j.destMeta.ClearTable(j.Dest.Database, destTableName)
 	}
 
@@ -2010,15 +2010,15 @@ func (j *Job) handleRenameTableRecord(renameTable *record.RenameTable) error {
 	}
 
 	err = j.IDest.RenameTable(destTableName, renameTable)
-    if err != nil {
-        return err
-    }
+	if err != nil {
+		return err
+	}
 
-    j.destMeta.GetTables()
-    if j.progress.TableNameMapping == nil {
-        j.progress.TableNameMapping = make(map[int64]string)
-    }
-    j.progress.TableNameMapping[renameTable.TableId] = renameTable.NewTableName
+	j.destMeta.GetTables()
+	if j.progress.TableNameMapping == nil {
+		j.progress.TableNameMapping = make(map[int64]string)
+	}
+	j.progress.TableNameMapping[renameTable.TableId] = renameTable.NewTableName
 
 	return nil
 }

--- a/pkg/ccr/job_progress.go
+++ b/pkg/ccr/job_progress.go
@@ -241,6 +241,16 @@ func NewJobProgressFromJson(jobName string, db storage.DB) (*JobProgress, error)
 	}
 }
 
+// GetTableId get table id by table name from TableNameMapping
+func (j *JobProgress) GetTableId(tableName string) (int64, bool) {
+	for tableId, table := range j.TableNameMapping {
+		if table == tableName {
+			return tableId, true
+		}
+	}
+	return 0, false
+}
+
 func (j *JobProgress) StartHandle(commitSeq int64) {
 	j.CommitSeq = commitSeq
 

--- a/pkg/utils/map.go
+++ b/pkg/utils/map.go
@@ -10,3 +10,14 @@ func CopyMap[K, V comparable](m map[K]V) map[K]V {
 	}
 	return result
 }
+
+// MergeMap returns a new map with all key-value pairs from both input maps.
+func MergeMap[K comparable, V any](m1, m2 map[K]V) map[K]V {
+	if m1 == nil {
+		m1 = make(map[K]V, len(m2))
+	}
+	for k, v := range m2 {
+		m1[k] = v
+	}
+	return m1
+}

--- a/regression-test/suites/cross_ds/part/drop/add/test_cds_part_add_drop.groovy
+++ b/regression-test/suites/cross_ds/part/drop/add/test_cds_part_add_drop.groovy
@@ -15,19 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_cds_tbl_rename_alter") {
+suite("test_cds_part_add_drop") {
     def helper = new GroovyShell(new Binding(['suite': delegate]))
             .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
 
-    if (!helper.is_version_supported([30003, 20108, 20016])) {
-        // at least doris 3.0.3, 2.1.8 and doris 2.0.16
-        def version = helper.upstream_version()
-        logger.info("skip this suite because version is not supported, upstream version ${version}")
-        return
-    }
-
-    def oldTableName = "tbl_old_" + helper.randomSuffix()
-    def newTableName = "tbl_new_" + helper.randomSuffix()
+    def baseTableName = "test_" + helper.randomSuffix()
+    def test_num = 0
+    def insert_num = 5
+    def opPartitonName = "less0"
 
     def exist = { res -> Boolean
         return res.size() != 0
@@ -36,22 +31,20 @@ suite("test_cds_tbl_rename_alter") {
         return res.size() == 0
     }
 
-    logger.info("=== Create both table ===")
+    logger.info("=== Test 1: Add range partition ===")
+    def tableName = "${baseTableName}_range"
     sql """
-        CREATE TABLE if NOT EXISTS ${oldTableName}
+        CREATE TABLE if NOT EXISTS ${tableName}
         (
             `test` INT,
-            `id` INT
+            `id` INT NOT NULL
         )
         ENGINE=OLAP
         UNIQUE KEY(`test`, `id`)
         PARTITION BY RANGE(`id`)
         (
             PARTITION `p1` VALUES LESS THAN ("0"),
-            PARTITION `p2` VALUES LESS THAN ("100"),
-            PARTITION `p3` VALUES LESS THAN ("200"),
-            PARTITION `p4` VALUES LESS THAN ("300"),
-            PARTITION `p5` VALUES LESS THAN ("1000")
+            PARTITION `p2` VALUES LESS THAN ("100")
         )
         DISTRIBUTED BY HASH(id) BUCKETS AUTO
         PROPERTIES (
@@ -64,38 +57,45 @@ suite("test_cds_tbl_rename_alter") {
     helper.ccrJobDelete()
     helper.ccrJobCreate()
 
-    assertTrue(helper.checkRestoreFinishTimesOf("${oldTableName}", 60))
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 60))
 
-    sql "INSERT INTO ${oldTableName} VALUES (1, 100), (100, 1), (2, 200), (200, 2)"
-    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${oldTableName}", 4, 60))
-
-    logger.info(" ==== alter table and rename ==== ")
+    logger.info("Add partition and drop")
 
     def first_job_progress = helper.get_job_progress()
 
-    helper.ccrJobPause()
-
-    sql "ALTER TABLE ${oldTableName} ADD COLUMN `new_col` INT KEY DEFAULT \"0\""
+    sql """
+        ALTER TABLE ${tableName} ADD PARTITION p3 VALUES LESS THAN ("200")
+        """
 
     assertTrue(helper.checkShowTimesOf("""
-                                SHOW ALTER TABLE COLUMN
-                                FROM ${context.dbName}
-                                WHERE TableName = "${oldTableName}" AND State = "FINISHED"
+                                SHOW PARTITIONS
+                                FROM ${tableName}
+                                WHERE PartitionName = "p3"
                                 """,
-                                exist, 30))
+                                exist, 60, "sql"))
 
-    sql "INSERT INTO ${oldTableName} VALUES (5, 500, 1)"
-    sql "ALTER TABLE ${oldTableName} RENAME ${newTableName}"
-    sql "INSERT INTO ${newTableName} VALUES (6, 600, 2)"
+    sql "INSERT INTO ${tableName} VALUES (1, 150)"
+
+    sql """
+        ALTER TABLE ${tableName} DROP PARTITION p3
+        """
+
+    sql "INSERT INTO ${tableName} VALUES (2, 10)"
 
     helper.ccrJobResume()
 
-    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${newTableName}\"", exist, 60, "target"))
-    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${newTableName}", 6, 60))
+    assertTrue(helper.checkSelectTimesOf("""
+                                SELECT * FROM ${tableName}
+                                WHERE id = 150
+                                """,
+                                0, 60))
+    assertTrue(helper.checkSelectTimesOf("""
+                                SELECT * FROM ${tableName}
+                                WHERE id = 10
+                                """,
+                                1, 60))
 
     // no fullsync are triggered
     def last_job_progress = helper.get_job_progress()
     assertTrue(last_job_progress.full_sync_start_at == first_job_progress.full_sync_start_at)
 }
-
-

--- a/regression-test/suites/cross_ds/table/backup/create_drop/test_cds_tbl_backup_create_drop.groovy
+++ b/regression-test/suites/cross_ds/table/backup/create_drop/test_cds_tbl_backup_create_drop.groovy
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_cds_tbl_backup_create_drop") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    if (!helper.is_version_supported([30003, 20108, 20016])) {
+        // at least doris 3.0.3, 2.1.8 and doris 2.0.16
+        def version = helper.upstream_version()
+        logger.info("skip this suite because version is not supported, upstream version ${version}")
+        return
+    }
+
+    def tableName = "tbl_" + helper.randomSuffix()
+    def test_num = 0
+    def insert_num = 10
+    def opPartitonName = "less"
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+    def notExist = { res -> Boolean
+        return res.size() == 0
+    }
+
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}_1
+        (
+            `test` INT,
+            `id` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`test`, `id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION `${opPartitonName}_0` VALUES LESS THAN ("0"),
+            PARTITION `${opPartitonName}_1` VALUES LESS THAN ("1000")
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+
+    def prefix = helper.get_backup_lable_prefix()
+    GetDebugPoint().enableDebugPointForAllFEs("FE.PAUSE_PENDING_BACKUP_JOB", [value: prefix])
+
+    helper.enableDbBinlog()
+    helper.ccrJobDelete()
+    helper.ccrJobCreate()
+
+    // Wait for backup job to running
+    def is_backup_running = { res ->
+        for (int i = 0; i < res.size(); i++) {
+            logger.info("backup job status: ${res[i]}")
+            if (res[i][3] != "CANCELLED" && res[i][3] != "FINISHED") {
+                return true
+            }
+        }
+        return false
+    }
+    assertTrue(helper.checkShowTimesOf(
+        """ SHOW BACKUP WHERE SnapshotName LIKE "${prefix}%" """,
+        is_backup_running, 60))
+
+    logger.info("create new table and drop it immediatelly")
+
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}_2
+        (
+            `test` INT,
+            `id` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`test`, `id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION `${opPartitonName}_0` VALUES LESS THAN ("0"),
+            PARTITION `${opPartitonName}_1` VALUES LESS THAN ("1000")
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    sql "DROP TABLE ${tableName}_2 FORCE"
+    sql "INSERT INTO ${tableName}_1 VALUES (1, 1)"
+    sql "sync"
+
+    GetDebugPoint().disableDebugPointForAllFEs("FE.PAUSE_PENDING_BACKUP_JOB")
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}_1", 60))
+
+    sql "INSERT INTO ${tableName}_1 VALUES (2, 2)"
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}_1", 2, 60))
+}
+

--- a/regression-test/suites/cross_ds/table/drop/create/test_cds_tbl_create_drop.groovy
+++ b/regression-test/suites/cross_ds/table/drop/create/test_cds_tbl_create_drop.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_cds_tbl_rename_alter") {
+suite("test_cds_tbl_create_drop") {
     def helper = new GroovyShell(new Binding(['suite': delegate]))
             .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
 
@@ -36,9 +36,9 @@ suite("test_cds_tbl_rename_alter") {
         return res.size() == 0
     }
 
-    logger.info("=== Create both table ===")
+    logger.info("=== Create a fake table ===")
     sql """
-        CREATE TABLE if NOT EXISTS ${oldTableName}
+        CREATE TABLE if NOT EXISTS ${oldTableName}_fake
         (
             `test` INT,
             `id` INT
@@ -64,38 +64,51 @@ suite("test_cds_tbl_rename_alter") {
     helper.ccrJobDelete()
     helper.ccrJobCreate()
 
-    assertTrue(helper.checkRestoreFinishTimesOf("${oldTableName}", 60))
+    assertTrue(helper.checkRestoreFinishTimesOf("${oldTableName}_fake", 60))
 
-    sql "INSERT INTO ${oldTableName} VALUES (1, 100), (100, 1), (2, 200), (200, 2)"
-    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${oldTableName}", 4, 60))
-
-    logger.info(" ==== alter table and rename ==== ")
+    logger.info(" ==== create table and drop ==== ")
 
     def first_job_progress = helper.get_job_progress()
 
     helper.ccrJobPause()
 
-    sql "ALTER TABLE ${oldTableName} ADD COLUMN `new_col` INT KEY DEFAULT \"0\""
+    sql """
+        CREATE TABLE if NOT EXISTS ${oldTableName}
+        (
+            `test` INT,
+            `id` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`test`, `id`)
+        PARTITION BY RANGE(`id`)
+        (
+            PARTITION `p1` VALUES LESS THAN ("0"),
+            PARTITION `p2` VALUES LESS THAN ("100"),
+            PARTITION `p3` VALUES LESS THAN ("200"),
+            PARTITION `p4` VALUES LESS THAN ("300"),
+            PARTITION `p5` VALUES LESS THAN ("1000")
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS AUTO
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
 
-    assertTrue(helper.checkShowTimesOf("""
-                                SHOW ALTER TABLE COLUMN
-                                FROM ${context.dbName}
-                                WHERE TableName = "${oldTableName}" AND State = "FINISHED"
-                                """,
-                                exist, 30))
-
-    sql "INSERT INTO ${oldTableName} VALUES (5, 500, 1)"
-    sql "ALTER TABLE ${oldTableName} RENAME ${newTableName}"
-    sql "INSERT INTO ${newTableName} VALUES (6, 600, 2)"
+    sql "INSERT INTO ${oldTableName} VALUES (1, 100), (100, 1), (2, 200), (200, 2)"
+    sql "INSERT INTO ${oldTableName} VALUES (5, 500)"
+    sql "DROP TABLE ${oldTableName} FORCE"
 
     helper.ccrJobResume()
 
-    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${newTableName}\"", exist, 60, "target"))
-    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${newTableName}", 6, 60))
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${oldTableName}\"", notExist, 60, "target"))
 
     // no fullsync are triggered
     def last_job_progress = helper.get_job_progress()
     assertTrue(last_job_progress.full_sync_start_at == first_job_progress.full_sync_start_at)
 }
+
+
+
 
 


### PR DESCRIPTION
Partial snapshot/Create table/Drop table/Truncate table depends the upstream table name, which might be staled, when the table is renamed/replaced in upstream