### PR TITLE
Support check table properties for table sync

### DIFF
--- a/cmd/spec_checker/spec_checker.go
+++ b/cmd/spec_checker/spec_checker.go
@@ -26,7 +26,7 @@ func checkDBEnableBinlog(db string) {
 	}
 }
 
-func checkTableEnableBinlog(table string) {
+func CheckTableProperty(table string) {
 	src := &base.Spec{
 		Frontend: base.Frontend{
 			Host:       "localhost",
@@ -39,7 +39,7 @@ func checkTableEnableBinlog(table string) {
 		Table:    table,
 	}
 
-	if dbEnableBinlog, err := src.IsTableEnableBinlog(); err != nil {
+	if dbEnableBinlog, err := src.CheckTablePropertyValid(); err != nil {
 		panic(err)
 	} else {
 		log.Infof("table: ccr.%v enable binlog: %v", table, dbEnableBinlog)
@@ -52,8 +52,8 @@ func testDBEnableBinlog() {
 }
 
 func testTableEnableBinlog() {
-	checkTableEnableBinlog("src_1")
-	checkTableEnableBinlog("tbl_day")
+	CheckTableProperty("src_1")
+	CheckTableProperty("tbl_day")
 }
 
 func testGetAllTables() {

--- a/pkg/ccr/base/specer.go
+++ b/pkg/ccr/base/specer.go
@@ -16,7 +16,6 @@ const (
 type Specer interface {
 	Valid() error
 	IsDatabaseEnableBinlog() (bool, error)
-	IsTableEnableBinlog() (bool, error)
 	IsEnableRestoreSnapshotCompression() (bool, error)
 	GetAllTables() ([]string, error)
 	GetAllViewsFromTable(tableName string) ([]string, error)
@@ -25,6 +24,7 @@ type Specer interface {
 	CreateTableOrView(createTable *record.CreateTable, srcDatabase string) error
 	CheckDatabaseExists() (bool, error)
 	CheckTableExists() (bool, error)
+	CheckTablePropertyValid() ([]string, error)
 	CheckTableExistsByName(tableName string) (bool, error)
 	GetValidBackupJob(snapshotNamePrefix string) (string, error)
 	GetValidRestoreJob(snapshotNamePrefix string) (string, error)

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -3247,10 +3247,10 @@ func (j *Job) FirstRun() error {
 			return xerror.Errorf(xerror.Normal, "src table %s.%s not exists", j.Src.Database, j.Src.Table)
 		}
 
-		if enable, err := j.ISrc.IsTableEnableBinlog(); err != nil {
+		if invalidProperty, err := j.ISrc.CheckTablePropertyValid(); err != nil {
 			return err
-		} else if !enable {
-			return xerror.Errorf(xerror.Normal, "src table %s.%s not enable binlog", j.Src.Database, j.Src.Table)
+		} else if len(invalidProperty) != 0 {
+			return xerror.Errorf(xerror.Normal, "src table %s.%s only support property: %s", j.Src.Database, j.Src.Table, strings.Join(invalidProperty, ", "))
 		}
 
 		if srcTableId, err := j.srcMeta.GetTableId(j.Src.Table); err != nil {


### PR DESCRIPTION
If there are invalid property in the table, creating a task will return an error and print the support property
example:
```
{"success":false,"error_msg":"[normal] src table wyx.t only support property: \"binlog.enable\" = \"true\", \"light_schema_change\" = \"true\""}
```

properties are not supported so far:
```
"light_schema_change" = "false"

"binlog.enable" = "false"
```