### PR TITLE
Fixed database deadlock when syncer crash

### DIFF
--- a/pkg/storage/mysql.go
+++ b/pkg/storage/mysql.go
@@ -100,7 +100,9 @@ func (s *MysqlDB) UpdateJob(jobName string, jobInfo string) error {
 }
 
 func (s *MysqlDB) RemoveJob(jobName string) error {
-	txn, err := s.db.BeginTx(context.Background(), &sql.TxOptions{
+	var err error
+	var txn *sql.Tx
+	txn, err = s.db.BeginTx(context.Background(), &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	})
@@ -115,21 +117,15 @@ func (s *MysqlDB) RemoveJob(jobName string) error {
 		}
 	}()
 
-	if _, err := txn.Exec(fmt.Sprintf("DELETE FROM jobs WHERE job_name = '%s'", jobName)); err != nil {
-		if err := txn.Rollback(); err != nil {
-			return xerror.Wrapf(err, xerror.DB, "mysql: remove job failed, name: %s, and rollback failed too", jobName)
-		}
+	if _, err = txn.Exec(fmt.Sprintf("DELETE FROM jobs WHERE job_name = '%s'", jobName)); err != nil {
 		return xerror.Wrapf(err, xerror.DB, "mysql: remove job failed, name: %s", jobName)
 	}
 
-	if _, err := txn.Exec(fmt.Sprintf("DELETE FROM progresses WHERE job_name = '%s'", jobName)); err != nil {
-		if err := txn.Rollback(); err != nil {
-			return xerror.Wrapf(err, xerror.DB, "mysql: remove progresses failed, name: %s, and rollback failed too", jobName)
-		}
+	if _, err = txn.Exec(fmt.Sprintf("DELETE FROM progresses WHERE job_name = '%s'", jobName)); err != nil {
 		return xerror.Wrapf(err, xerror.DB, "mysql: remove progresses failed, name: %s", jobName)
 	}
 
-	if err := txn.Commit(); err != nil {
+	if err = txn.Commit(); err != nil {
 		return xerror.Wrapf(err, xerror.DB, "mysql: remove job txn commit failed.")
 	}
 
@@ -228,7 +224,9 @@ func (s *MysqlDB) RefreshSyncer(hostInfo string, lastStamp int64) (int64, error)
 }
 
 func (s *MysqlDB) GetStampAndJobs(hostInfo string) (int64, []string, error) {
-	txn, err := s.db.BeginTx(context.Background(), &sql.TxOptions{
+	var err error
+	var txn *sql.Tx
+	txn, err = s.db.BeginTx(context.Background(), &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 	})
 	if err != nil {
@@ -243,12 +241,13 @@ func (s *MysqlDB) GetStampAndJobs(hostInfo string) (int64, []string, error) {
 	}()
 
 	var timestamp int64
-	if err := txn.QueryRow(fmt.Sprintf("SELECT timestamp FROM syncers WHERE host_info = '%s'", hostInfo)).Scan(&timestamp); err != nil {
+	if err = txn.QueryRow(fmt.Sprintf("SELECT timestamp FROM syncers WHERE host_info = '%s'", hostInfo)).Scan(&timestamp); err != nil {
 		return -1, nil, xerror.Wrapf(err, xerror.DB, "mysql: get stamp failed.")
 	}
 
 	jobs := make([]string, 0)
-	rows, err := s.db.Query(fmt.Sprintf("SELECT job_name FROM jobs WHERE belong_to = '%s'", hostInfo))
+	var rows *sql.Rows
+	rows, err = s.db.Query(fmt.Sprintf("SELECT job_name FROM jobs WHERE belong_to = '%s'", hostInfo))
 	if err != nil {
 		return -1, nil, xerror.Wrapf(err, xerror.DB, "mysql: get job_nums failed.")
 	}
@@ -256,13 +255,13 @@ func (s *MysqlDB) GetStampAndJobs(hostInfo string) (int64, []string, error) {
 
 	for rows.Next() {
 		var jobName string
-		if err := rows.Scan(&jobName); err != nil {
+		if err = rows.Scan(&jobName); err != nil {
 			return -1, nil, xerror.Wrapf(err, xerror.DB, "mysql: scan job_name failed.")
 		}
 		jobs = append(jobs, jobName)
 	}
 
-	if err := txn.Commit(); err != nil {
+	if err = txn.Commit(); err != nil {
 		return -1, nil, xerror.Wrapf(err, xerror.DB, "mysql: get jobs & stamp txn commit failed.")
 	}
 
@@ -349,7 +348,9 @@ func (s *MysqlDB) dispatchJobs(txn *sql.Tx, hostInfo string, additionalJobs []st
 }
 
 func (s *MysqlDB) RebalanceLoadFromDeadSyncers(syncers []string) error {
-	txn, err := s.db.BeginTx(context.Background(), &sql.TxOptions{
+	var err error
+	var txn *sql.Tx
+	txn, err = s.db.BeginTx(context.Background(), &sql.TxOptions{
 		Isolation: sql.LevelSerializable,
 		ReadOnly:  false,
 	})
@@ -370,7 +371,9 @@ func (s *MysqlDB) RebalanceLoadFromDeadSyncers(syncers []string) error {
 	}
 
 	additionalLoad := len(orphanJobs)
-	loadList, currentLoad, err := s.getLoadInfo(txn)
+	var loadList LoadSlice
+	var currentLoad int
+	loadList, currentLoad, err = s.getLoadInfo(txn)
 	if err != nil {
 		return err
 	}
@@ -381,16 +384,13 @@ func (s *MysqlDB) RebalanceLoadFromDeadSyncers(syncers []string) error {
 	}
 	for i := range loadList {
 		beginIdx := additionalLoad - loadList[i].AddedLoad
-		if err := s.dispatchJobs(txn, loadList[i].HostInfo, orphanJobs[beginIdx:additionalLoad]); err != nil {
-			if err := txn.Rollback(); err != nil {
-				return xerror.Wrap(err, xerror.DB, "mysql: rebalance rollback failed.")
-			}
+		if err = s.dispatchJobs(txn, loadList[i].HostInfo, orphanJobs[beginIdx:additionalLoad]); err != nil {
 			return err
 		}
 		additionalLoad = beginIdx
 	}
 
-	if err := txn.Commit(); err != nil {
+	if err = txn.Commit(); err != nil {
 		return xerror.Wrap(err, xerror.DB, "mysql: rebalance txn commit failed.")
 	}
 

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -83,7 +83,9 @@ func (s *PostgresqlDB) UpdateJob(jobName string, jobInfo string) error {
 }
 
 func (s *PostgresqlDB) RemoveJob(jobName string) error {
-	txn, err := s.db.BeginTx(context.Background(), &sql.TxOptions{
+	var err error
+	var txn *sql.Tx
+	txn, err = s.db.BeginTx(context.Background(), &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  false,
 	})
@@ -98,21 +100,15 @@ func (s *PostgresqlDB) RemoveJob(jobName string) error {
 		}
 	}()
 
-	if _, err := txn.Exec(fmt.Sprintf("DELETE FROM %s.jobs WHERE job_name = '%s'", remoteDBName, jobName)); err != nil {
-		if err := txn.Rollback(); err != nil {
-			return xerror.Wrapf(err, xerror.DB, "postgresql: remove job failed, name: %s, and rollback failed too", jobName)
-		}
+	if _, err = txn.Exec(fmt.Sprintf("DELETE FROM %s.jobs WHERE job_name = '%s'", remoteDBName, jobName)); err != nil {
 		return xerror.Wrapf(err, xerror.DB, "postgresql: remove job failed, name: %s", jobName)
 	}
 
-	if _, err := txn.Exec(fmt.Sprintf("DELETE FROM %s.progresses WHERE job_name = '%s'", remoteDBName, jobName)); err != nil {
-		if err := txn.Rollback(); err != nil {
-			return xerror.Wrapf(err, xerror.DB, "postgresql: remove progresses failed, name: %s, and rollback failed too", jobName)
-		}
+	if _, err = txn.Exec(fmt.Sprintf("DELETE FROM %s.progresses WHERE job_name = '%s'", remoteDBName, jobName)); err != nil {
 		return xerror.Wrapf(err, xerror.DB, "postgresql: remove progresses failed, name: %s", jobName)
 	}
 
-	if err := txn.Commit(); err != nil {
+	if err = txn.Commit(); err != nil {
 		return xerror.Wrapf(err, xerror.DB, "postgresql: remove job txn commit failed.")
 	}
 
@@ -213,7 +209,9 @@ func (s *PostgresqlDB) RefreshSyncer(hostInfo string, lastStamp int64) (int64, e
 }
 
 func (s *PostgresqlDB) GetStampAndJobs(hostInfo string) (int64, []string, error) {
-	txn, err := s.db.BeginTx(context.Background(), &sql.TxOptions{
+	var err error
+	var txn *sql.Tx
+	txn, err = s.db.BeginTx(context.Background(), &sql.TxOptions{
 		Isolation: sql.LevelRepeatableRead,
 		ReadOnly:  true,
 	})
@@ -229,12 +227,13 @@ func (s *PostgresqlDB) GetStampAndJobs(hostInfo string) (int64, []string, error)
 	}()
 
 	var timestamp int64
-	if err := txn.QueryRow(fmt.Sprintf("SELECT timestamp FROM %s.syncers WHERE host_info = '%s'", remoteDBName, hostInfo)).Scan(&timestamp); err != nil {
+	if err = txn.QueryRow(fmt.Sprintf("SELECT timestamp FROM %s.syncers WHERE host_info = '%s'", remoteDBName, hostInfo)).Scan(&timestamp); err != nil {
 		return -1, nil, xerror.Wrapf(err, xerror.DB, "postgresql: get stamp failed.")
 	}
 
 	jobs := make([]string, 0)
-	rows, err := s.db.Query(fmt.Sprintf("SELECT job_name FROM %s.jobs WHERE belong_to = '%s'", remoteDBName, hostInfo))
+	var rows *sql.Rows
+	rows, err = s.db.Query(fmt.Sprintf("SELECT job_name FROM %s.jobs WHERE belong_to = '%s'", remoteDBName, hostInfo))
 	if err != nil {
 		return -1, nil, xerror.Wrapf(err, xerror.DB, "postgresql: get job_nums failed.")
 	}
@@ -242,13 +241,13 @@ func (s *PostgresqlDB) GetStampAndJobs(hostInfo string) (int64, []string, error)
 
 	for rows.Next() {
 		var jobName string
-		if err := rows.Scan(&jobName); err != nil {
+		if err = rows.Scan(&jobName); err != nil {
 			return -1, nil, xerror.Wrapf(err, xerror.DB, "postgresql: scan job_name failed.")
 		}
 		jobs = append(jobs, jobName)
 	}
 
-	if err := txn.Commit(); err != nil {
+	if err = txn.Commit(); err != nil {
 		return -1, nil, xerror.Wrapf(err, xerror.DB, "postgresql: get jobs & stamp txn commit failed.")
 	}
 
@@ -338,7 +337,9 @@ func (s *PostgresqlDB) dispatchJobs(txn *sql.Tx, hostInfo string, additionalJobs
 }
 
 func (s *PostgresqlDB) RebalanceLoadFromDeadSyncers(syncers []string) error {
-	txn, err := s.db.BeginTx(context.Background(), &sql.TxOptions{
+	var err error
+	var txn *sql.Tx
+	txn, err = s.db.BeginTx(context.Background(), &sql.TxOptions{
 		Isolation: sql.LevelSerializable,
 		ReadOnly:  false,
 	})
@@ -353,13 +354,16 @@ func (s *PostgresqlDB) RebalanceLoadFromDeadSyncers(syncers []string) error {
 		}
 	}()
 
-	orphanJobs, err := s.getOrphanJobs(txn, syncers)
+	var orphanJobs []string
+	orphanJobs, err = s.getOrphanJobs(txn, syncers)
 	if err != nil {
 		return err
 	}
 
 	additionalLoad := len(orphanJobs)
-	loadList, currentLoad, err := s.getLoadInfo(txn)
+	var loadList LoadSlice
+	var currentLoad int
+	loadList, currentLoad, err = s.getLoadInfo(txn)
 	if err != nil {
 		return err
 	}
@@ -370,16 +374,13 @@ func (s *PostgresqlDB) RebalanceLoadFromDeadSyncers(syncers []string) error {
 	}
 	for i := range loadList {
 		beginIdx := additionalLoad - loadList[i].AddedLoad
-		if err := s.dispatchJobs(txn, loadList[i].HostInfo, orphanJobs[beginIdx:additionalLoad]); err != nil {
-			if err := txn.Rollback(); err != nil {
-				return xerror.Wrap(err, xerror.DB, "postgresql: rebalance rollback failed.")
-			}
+		if err = s.dispatchJobs(txn, loadList[i].HostInfo, orphanJobs[beginIdx:additionalLoad]); err != nil {
 			return err
 		}
 		additionalLoad = beginIdx
 	}
 
-	if err := txn.Commit(); err != nil {
+	if err = txn.Commit(); err != nil {
 		return xerror.Wrap(err, xerror.DB, "postgresql: rebalance txn commit failed.")
 	}
 

--- a/pkg/storage/utils.go
+++ b/pkg/storage/utils.go
@@ -37,8 +37,8 @@ func (ls LoadSlice) Swap(i, j int) {
 
 func filterHighLoadSyncer(sumLoad int, loadList LoadSlice) (LoadSlice, int, error) {
 	sort.Sort(loadList)
-	if len(loadList) == 0 {
-		return nil, 0, xerror.Errorf(xerror.Normal, "loadList is empty!")
+	if len(loadList) == 0 || sumLoad == 0 {
+		return make(LoadSlice, 0), 0, nil
 	}
 	averageLoad := float64(sumLoad) / float64(len(loadList))
 	for i := len(loadList) - 1; i >= 0; i-- {
@@ -54,6 +54,10 @@ func RebalanceLoad(additionalLoad int, currentLoad int, loadList LoadSlice) (Loa
 	load, sumLoad, err := filterHighLoadSyncer(additionalLoad+currentLoad, loadList)
 	if err != nil {
 		return nil, err
+	}
+
+	if sumLoad == 0 || len(load) == 0 {
+		return make(LoadSlice, 0), nil
 	}
 
 	averageLoad := sumLoad / len(load)

--- a/shell/start_syncer.sh
+++ b/shell/start_syncer.sh
@@ -196,7 +196,7 @@ if [[ "${RUN_DAEMON}" -eq 1 ]]; then
           "$@" >>"${LOG_DIR}" 2>&1 </dev/null &
     echo $! > ${pidfile}
 else
-    exec "${SYNCER_HOME}/bin/ccr_syncer" \
+    "${SYNCER_HOME}/bin/ccr_syncer" \
         "-db_dir=${DB_DIR}" \
         "-db_type=${DB_TYPE}" \
         "-db_host=${DB_HOST}" \

--- a/shell/start_syncer.sh
+++ b/shell/start_syncer.sh
@@ -196,7 +196,7 @@ if [[ "${RUN_DAEMON}" -eq 1 ]]; then
           "$@" >>"${LOG_DIR}" 2>&1 </dev/null &
     echo $! > ${pidfile}
 else
-    "${SYNCER_HOME}/bin/ccr_syncer" \
+    exec "${SYNCER_HOME}/bin/ccr_syncer" \
         "-db_dir=${DB_DIR}" \
         "-db_type=${DB_TYPE}" \
         "-db_host=${DB_HOST}" \


### PR DESCRIPTION
Currently, in database transaction processing, if an exception occurs without abort, there is no lock release.
When a node dies and there is no sync task, there is a divisor 0 exception in RebalanceLoad.

```
ERROR checker failed, host info: 10.119.48.44:8411, err: [db] Error 1205 (HY000): Lock wait timeout exceeded; try restarting transaction

panic: runtime error: integer divide by zero

goroutine 187 [running]:
github.com/selectdb/ccr_syncer/pkg/storage.RebalanceLoad(0x0, 0xb36dc8?, {0xc0006b82a0?, 0x1?, 0x30?})
        /root/src/ccr-syncer-data/pkg/storage/utils.go:59 +0xea
github.com/selectdb/ccr_syncer/pkg/storage.(*MysqlDB).RebalanceLoadFromDeadSyncers(0xc000534070, {0xc0000fb340, 0x1, 0x1})
        /root/src/ccr-syncer-data/pkg/storage/mysql.go:378 +0x1ab
github.com/selectdb/ccr_syncer/pkg/ccr.(*Checker).handleRebalance(0xc0001d4000)
        /root/src/ccr-syncer-data/pkg/ccr/checker.go:128 +0x92
```
