### PR TITLE
Limit the connections

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -3117,6 +3117,7 @@ func (j *Job) Run() error {
 		isProgressExist, err = j.db.IsProgressExist(j.Name)
 		if err != nil {
 			log.Errorf("check progress exist failed, error: %+v", err)
+			time.Sleep(time.Second * time.Duration(i*2))
 			continue
 		}
 		break

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -3117,7 +3117,6 @@ func (j *Job) Run() error {
 		isProgressExist, err = j.db.IsProgressExist(j.Name)
 		if err != nil {
 			log.Errorf("check progress exist failed, error: %+v", err)
-			time.Sleep(time.Second * time.Duration(i*2))
 			continue
 		}
 		break

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -1,6 +1,9 @@
 package storage
 
-import "errors"
+import (
+	"errors"
+	"flag"
+)
 
 var (
 	ErrJobExists    = errors.New("job exists")
@@ -8,10 +11,20 @@ var (
 )
 
 const (
-	InvalidCheckTimestamp int64  = -1
-	remoteDBName          string = "ccr"
-	maxOpenConnctions     int    = 20
+	InvalidCheckTimestamp    int64  = -1
+	remoteDBName             string = "ccr"
+	defaultMaxOpenConnctions int    = 20
 )
+
+var maxOpenConnctions int
+var maxAllowedPacket int64
+
+func init() {
+	flag.Int64Var(&maxAllowedPacket, "mysql_max_allowed_packet", defaultMaxAllowedPacket,
+		"Config the max allowed packet to send to mysql server, the upper limit is 1GB")
+	flag.IntVar(&maxOpenConnctions, "max_open_connection", defaultMaxOpenConnctions,
+		"Config the max open connections for db user")
+}
 
 type DB interface {
 	// Add ccr job

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -10,6 +10,7 @@ var (
 const (
 	InvalidCheckTimestamp int64  = -1
 	remoteDBName          string = "ccr"
+	maxOpenConnctions     int    = 20
 )
 
 type DB interface {

--- a/pkg/storage/mysql.go
+++ b/pkg/storage/mysql.go
@@ -33,6 +33,9 @@ func NewMysqlDB(host string, port int, user string, password string) (DB, error)
 		return nil, xerror.Wrapf(err, xerror.DB, "mysql: open %s@tcp(%s:%s) failed", user, host, password)
 	}
 
+	dbForDDL.SetMaxOpenConns(maxOpenConnctions)
+	dbForDDL.SetMaxIdleConns(maxOpenConnctions / 2)
+
 	if _, err := dbForDDL.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", remoteDBName)); err != nil {
 		return nil, xerror.Wrapf(err, xerror.DB, "mysql: create database %s failed", remoteDBName)
 	}
@@ -42,6 +45,9 @@ func NewMysqlDB(host string, port int, user string, password string) (DB, error)
 	if err != nil {
 		return nil, xerror.Wrapf(err, xerror.DB, "mysql: open mysql in db %s@tcp(%s:%d)/%s failed", user, host, port, remoteDBName)
 	}
+
+	db.SetMaxOpenConns(maxOpenConnctions)
+	db.SetMaxIdleConns(maxOpenConnctions / 2)
 
 	if _, err = db.Exec("CREATE TABLE IF NOT EXISTS jobs (`job_name` VARCHAR(512) PRIMARY KEY, `job_info` TEXT, `belong_to` VARCHAR(96))"); err != nil {
 		return nil, xerror.Wrap(err, xerror.DB, "mysql: create table jobs failed")

--- a/pkg/storage/mysql.go
+++ b/pkg/storage/mysql.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/base64"
-	"flag"
 	"fmt"
 	"time"
 
@@ -15,13 +14,6 @@ import (
 const (
 	defaultMaxAllowedPacket = 1024 * 1024 * 1024
 )
-
-var maxAllowedPacket int64
-
-func init() {
-	flag.Int64Var(&maxAllowedPacket, "mysql_max_allowed_packet", defaultMaxAllowedPacket,
-		"Config the max allowed packet to send to mysql server, the upper limit is 1GB")
-}
 
 type MysqlDB struct {
 	db *sql.DB
@@ -34,7 +26,7 @@ func NewMysqlDB(host string, port int, user string, password string) (DB, error)
 	}
 
 	dbForDDL.SetMaxOpenConns(maxOpenConnctions)
-	dbForDDL.SetMaxIdleConns(maxOpenConnctions / 2)
+	dbForDDL.SetMaxIdleConns(maxOpenConnctions / 4)
 
 	if _, err := dbForDDL.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", remoteDBName)); err != nil {
 		return nil, xerror.Wrapf(err, xerror.DB, "mysql: create database %s failed", remoteDBName)
@@ -47,7 +39,7 @@ func NewMysqlDB(host string, port int, user string, password string) (DB, error)
 	}
 
 	db.SetMaxOpenConns(maxOpenConnctions)
-	db.SetMaxIdleConns(maxOpenConnctions / 2)
+	db.SetMaxIdleConns(maxOpenConnctions / 4)
 
 	if _, err = db.Exec("CREATE TABLE IF NOT EXISTS jobs (`job_name` VARCHAR(512) PRIMARY KEY, `job_info` TEXT, `belong_to` VARCHAR(96))"); err != nil {
 		return nil, xerror.Wrap(err, xerror.DB, "mysql: create table jobs failed")

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -22,6 +22,9 @@ func NewPostgresqlDB(host string, port int, user string, password string) (DB, e
 		return nil, xerror.Wrapf(err, xerror.DB, "postgresql: open %s:%d failed", host, port)
 	}
 
+	db.SetMaxOpenConns(maxOpenConnctions)
+	db.SetMaxIdleConns(maxOpenConnctions / 2)
+
 	if _, err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", remoteDBName)); err != nil {
 		return nil, xerror.Wrapf(err, xerror.DB, "postgresql: create schema %s failed", remoteDBName)
 	}

--- a/pkg/storage/postgresql.go
+++ b/pkg/storage/postgresql.go
@@ -23,7 +23,7 @@ func NewPostgresqlDB(host string, port int, user string, password string) (DB, e
 	}
 
 	db.SetMaxOpenConns(maxOpenConnctions)
-	db.SetMaxIdleConns(maxOpenConnctions / 2)
+	db.SetMaxIdleConns(maxOpenConnctions / 4)
 
 	if _, err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", remoteDBName)); err != nil {
 		return nil, xerror.Wrapf(err, xerror.DB, "postgresql: create schema %s failed", remoteDBName)

--- a/pkg/storage/sqlite.go
+++ b/pkg/storage/sqlite.go
@@ -20,6 +20,9 @@ func NewSQLiteDB(dbPath string) (DB, error) {
 		return nil, xerror.Wrapf(err, xerror.DB, "sqlite: open sqlite3 path %s failed", dbPath)
 	}
 
+	db.SetMaxOpenConns(maxOpenConnctions)
+	db.SetMaxIdleConns(maxOpenConnctions / 2)
+
 	// create table info && progress, if not exists
 	// all is tuple (string, string)
 	if _, err = db.Exec("CREATE TABLE IF NOT EXISTS jobs (job_name TEXT PRIMARY KEY, job_info TEXT, belong_to TEXT)"); err != nil {

--- a/pkg/storage/sqlite.go
+++ b/pkg/storage/sqlite.go
@@ -21,7 +21,7 @@ func NewSQLiteDB(dbPath string) (DB, error) {
 	}
 
 	db.SetMaxOpenConns(maxOpenConnctions)
-	db.SetMaxIdleConns(maxOpenConnctions / 2)
+	db.SetMaxIdleConns(maxOpenConnctions / 4)
 
 	// create table info && progress, if not exists
 	// all is tuple (string, string)


### PR DESCRIPTION
When mysql or pg is the meta database of ccr, the start command may be like this:
`sh start_syncer.sh --db_host 127.0.0.1 --db_type mysql --db_port 3306 --db_user aaa  --db_password "123456"`

If you have many jobs by ccr, and the above user 'aaa' has a limited number of connections by mysql or pg, when you restart ccr progress, the error will report:
`reach limit of connections`

So add a sleep time when retry