### PR TITLE
Support reusing binlog label by setting reuse_binlog_label when creat…

### DIFF
--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -82,6 +82,7 @@ type CreateCcrRequest struct {
 	SkipError bool      `json:"skip_error"`
 	// For table sync, allow to create ccr job even if the target table already exists.
 	AllowTableExists bool `json:"allow_table_exists"`
+	ReuseBinlogLabel bool `json:"reuse_binlog_label"`
 }
 
 // Stringer
@@ -117,6 +118,7 @@ func createCcr(request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobMana
 		Dest:             request.Dest,
 		SkipError:        request.SkipError,
 		AllowTableExists: request.AllowTableExists,
+		ReuseBinlogLabel: request.ReuseBinlogLabel,
 		Db:               db,
 		Factory:          jobManager.GetFactory(),
 	}


### PR DESCRIPTION
During the cluster upgrade process, preserve the import labels from the source cluster. This enhancement ensures that upstream tasks can switch to the new cluster transparently, preventing duplicate imports and improving the stability and efficiency of cluster migrations.