### PR TITLE
Fix incomplete replacement in create 

### DIFF
--- a/pkg/ccr/base/spec.go
+++ b/pkg/ccr/base/spec.go
@@ -631,6 +631,7 @@ func (s *Spec) CreateTableOrView(createTable *record.CreateTable, srcDatabase st
 	}
 
 	createSql = AddDBPrefixToCreateTableOrViewSql(s.Database, createSql)
+	createSql = ReplaceDBNameForCreateSql(createSql, srcDatabase, s.Database)
 
 	// Compatible with doris 2.1.x, see apache/doris#44834 for details.
 	for strings.Contains(createSql, "MAXVALUEMAXVALUE") {
@@ -1548,5 +1549,11 @@ func AddDBPrefixToCreateTableOrViewSql(dbName, createSql string) string {
 		createSql = re.ReplaceAllString(createSql,
 			fmt.Sprintf("CREATE %s %s.%s ", resource, dbName, viewName))
 	}
+	return createSql
+}
+
+func ReplaceDBNameForCreateSql(createSql, srcDbName, destName string) string {
+	re := regexp.MustCompile(fmt.Sprintf(" `%s`.", srcDbName))
+	createSql = re.ReplaceAllString(createSql, fmt.Sprintf(" `%s`.", destName))
 	return createSql
 }

--- a/pkg/ccr/base/spec_test.go
+++ b/pkg/ccr/base/spec_test.go
@@ -26,3 +26,21 @@ func TestAddDBPrefixToCreateTableOrViewSql(t *testing.T) {
 		}
 	}
 }
+
+func TestReplaceDBNameForCreateSql(t *testing.T) {
+	type TestCase struct {
+		origin, expect string
+	}
+
+	testCases := []TestCase{
+		{"CREATE VIEW `target_db`.`v` AS (select `origin_db`.`func`(`internal`.`target_db`.`create_view_table1`.`id`) as `c1`,abs(`internal`.`target_db`.`create_view_table1`.`id`) from `internal`.`target_db`.`create_view_table1`)", "CREATE VIEW `target_db`.`v` AS (select `target_db`.`func`(`internal`.`target_db`.`create_view_table1`.`id`) as `c1`,abs(`internal`.`target_db`.`create_view_table1`.`id`) from `internal`.`target_db`.`create_view_table1`)"},
+		{"CREATE VIEW `target_db`.`v` AS (select `origin_db_not_replace`.`func`(`internal`.`target_db`.`create_view_table1`.`id`) as `c1`,abs(`internal`.`target_db`.`create_view_table1`.`id`) from `internal`.`target_db`.`create_view_table1`)", "CREATE VIEW `target_db`.`v` AS (select `origin_db_not_replace`.`func`(`internal`.`target_db`.`create_view_table1`.`id`) as `c1`,abs(`internal`.`target_db`.`create_view_table1`.`id`) from `internal`.`target_db`.`create_view_table1`)"},
+		{"CREATE VIEW `target_db`.`v` AS (select `origin_db`.`func`(`internal`.`target_db`.`origin_db`.`id`) as `c1`,abs(`internal`.`target_db`.`origin_db`.`id`) from `internal`.`target_db`.`origin_db`)", "CREATE VIEW `target_db`.`v` AS (select `target_db`.`func`(`internal`.`target_db`.`origin_db`.`id`) as `c1`,abs(`internal`.`target_db`.`origin_db`.`id`) from `internal`.`target_db`.`origin_db`)"},
+	}
+
+	for i, c := range testCases {
+		if actual := base.ReplaceDBNameForCreateSql(c.origin, "origin_db", "target_db"); actual != c.expect {
+			t.Errorf("case %d failed, expect %s, but got %s", i, c.expect, actual)
+		}
+	}
+}


### PR DESCRIPTION
before
```
[2024-12-17 10:49:21.724] DEBUG original create view sql is 
CREATE VIEW `test_view_alias_udf_with_db` AS (select `wyx`.`alias_function_create_view_test`(`internal`.`wyx`.`create_view_table1`.`id`) 
as `c1`,abs(`internal`.`wyx`.`create_view_table1`.`id`) 
from `internal`.`wyx`.`create_view_table1`);, 
after replace, 
now sql is 
CREATE VIEW `test_view_alias_udf_with_db` 
AS (select `wyx`.`alias_function_create_view_test`(`internal`.`wyx1`.`create_view_table1`.`id`) 
as `c1`,abs(`internal`.`wyx1`.`create_view_table1`.`id`) 
from `internal`.`wyx1`.`create_view_table1`); 
job=test line=base/spec.go:630
```

now
```
[2024-12-17 11:36:24.239]  WARN job sync failed, job: test, err: exec sql CREATE VIEW `db1`.`test_view_alias_udf_with_db` AS (select `db1`.`alias_function_create_view_test`(`internal`.`db1`.`create_view_table1`.`id`) as `c1`,abs(`internal`.`db1`.`create_view_table1`.`id`) from `internal`.`db1`.`create_view_table1`); failed: [normal] Error 1105 (HY000): errCode = 2, detailMessage = Can not found function 'db1.alias_function_create_view_test'
```