### PR TITLE
Skip create view/table with resource

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -1888,6 +1888,9 @@ func (j *Job) handleCreateTable(binlog *festruct.TBinlog) error {
 		if strings.Contains(errMsg, "Can not found function") {
 			log.Warnf("skip creating table/view because the UDF function is not supported yet: %s", errMsg)
 			return nil
+		} else if strings.Contains(errMsg, "Can not find resource") {
+			log.Warnf("skip creating table/view for the resource is not supported yet: %s", errMsg)
+			return nil
 		}
 		if len(createTable.TableName) > 0 && IsSessionVariableRequired(errMsg) { // ignore doris 2.0.3
 			log.Infof("a session variable is required to create table %s, force partial snapshot, commit seq: %d, msg: %s",

--- a/regression-test/suites/db_sync/table/create_resource/test_ds_tbl_create_resource.groovy
+++ b/regression-test/suites/db_sync/table/create_resource/test_ds_tbl_create_resource.groovy
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_ds_tbl_create_resource") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    def dbName = context.dbName
+    def viewName = "view_" + helper.randomSuffix()
+    def tableName = "tbl_" + helper.randomSuffix()
+
+    String ak = getS3AK()
+    String sk = getS3SK()
+    String s3_endpoint = getS3Endpoint()
+    String region = getS3Region()
+    String bucket = context.config.otherConfigs.get("s3BucketName");
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+
+    def notExist = { res -> Boolean
+        return res.size() == 0
+    }
+
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql "DROP VIEW IF EXISTS ${viewName}"
+    target_sql "DROP TABLE IF EXISTS ${tableName}"
+    target_sql "DROP TABLE IF EXISTS ${viewName}"
+
+    def resource_name = "test_ds_tbl_create_resource_resource"
+
+    sql """ DROP RESOURCE IF EXISTS '${resource_name}' """
+    sql """
+        CREATE RESOURCE "${resource_name}"
+        PROPERTIES
+        (
+            "type" = "s3",
+            "s3.endpoint" = "${s3_endpoint}",
+            "s3.region" = "${region}",
+            "s3.access_key"= "${ak}",
+            "s3.secret_key" = "${sk}",
+            "s3.bucket" = "${bucket}"
+        );
+        """
+
+
+    helper.enableDbBinlog()
+
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `test` INT,
+            `id` INT
+        )
+        ENGINE=OLAP
+        AGGREGATE KEY(`test`, `id`)
+        PARTITION BY RANGE(`id`)
+        (
+        )
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+
+    helper.ccrJobDelete()
+    helper.ccrJobCreate()
+
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 30))
+
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName}\"", exist, 60, "sql"))
+
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName}\"", exist, 60, "target"))
+
+    sql """
+        create view ${viewName} as
+        SELECT * FROM S3 (
+                           "uri" = "https://${bucket}.${s3_endpoint}/regression/tvf/test_hive_text.text",
+                           "format" = "hive_text",
+                           "csv_schema"="k1:int;k2:string;k3:double",
+                           "resource" = "${resource_name}"
+                       )  where k1 > 100  order by k3,k2,k1;
+        """
+
+    assertTrue(helper.checkShowTimesOf("SHOW VIEWS WHERE Tables_in_${dbName} = \"${viewName}\"", exist, 60, "sql"))
+
+    assertTrue(helper.checkShowTimesOf("SHOW VIEWS WHERE Tables_in_TEST_${dbName} = \"${viewName}\"", notExist, 60, "target"))
+}


### PR DESCRIPTION
```
[2024-12-23 17:02:05.038] INFO create table or view sql:
CREATE VIEW db.v AS
select _table_valued_function_s3.id, _table_valued_function_s3.name,
_table_valued_function_s3.age
FROM S3(
"uri" = "xxx",
"format" = "json",
"csv_schema"="k1:int ;k2:string ;k3:int ",
"resource" = "s3t",
"strip_outer_array" = "true",
"read_json_by_line" = "true",
"use_path_style"="false"
);
job=test line=base/spec.go:643

[2024-12-23 17:02:05.041] WARN skip creating table/view for the resource is not supported yet: exec sql
CREATE VIEW db.v AS
select _table_valued_function_s3.id, _table_valued_function_s3.name,
_table_valued_function_s3.age
FROM S3(
"uri" = "xxx",
"format" = "json",
"csv_schema"="k1:int ;k2:string ;k3:int ",
"resource" = "s3t",
"strip_outer_array" = "true",
"read_json_by_line" = "true",
"use_path_style"="false"
);
failed: [normal] Error 1105 (HY000): errCode = 2, detailMessage = Can not build s3():
errCode = 2, detailMessage = Can not find resource: s3t
job=test line=ccr/job.go:1892
```