### PR TITLE
Support set table property

### DIFF
--- a/pkg/ccr/base/spec.go
+++ b/pkg/ccr/base/spec.go
@@ -1507,6 +1507,28 @@ func (s *Spec) DesyncTables(tables ...string) error {
 	return nil
 }
 
+func (s *Spec) ModifyTableProperty(destTableName string, modifyProperty *record.ModifyTableProperty) error {
+	dbName := utils.FormatKeywordName(s.Database)
+	destTableName = utils.FormatKeywordName(destTableName)
+	modifyProperty.Sql = strings.ReplaceAll(modifyProperty.Sql, "\u003d", "=")
+
+	supportedProperties := FilterUnsupportedProperties(modifyProperty)
+	if len(supportedProperties) == 0 {
+		log.Warnf("the whole table properties are invalid, skip modify table property")
+		return nil
+	}
+
+	kvs := make([]string, 0, len(supportedProperties))
+	for k, v := range supportedProperties {
+		kvs = append(kvs, fmt.Sprintf("\"%s\"=\"%s\"", k, v))
+	}
+
+	sql := fmt.Sprintf("ALTER TABLE %s.%s SET (%s)", dbName, destTableName, strings.Join(kvs, ", "))
+	log.Infof("modify table property sql: %s", sql)
+
+	return s.Exec(sql)
+}
+
 // Determine whether the error are network related, eg connection refused, connection reset, exposed from net packages.
 func isNetworkRelated(err error) bool {
 	msg := err.Error()
@@ -1571,4 +1593,24 @@ func ReplaceAndEscapeComment(input string) string {
 		content := strings.ReplaceAll(groups[1], `"`, `\"`)
 		return fmt.Sprintf(`COMMENT "%s"`, content)
 	})
+}
+
+func FilterUnsupportedProperties(modifyProperty *record.ModifyTableProperty) map[string]string {
+	invalidProps := map[string]struct{}{
+		"binlog.enable":            {},
+		"light_schema_change":      {},
+		"dynamic_partition.enable": {},
+		"colocate_with":            {},
+		"storage_policy":           {},
+		"replication_num":          {},
+		"replication_allocation":   {},
+		"is_being_synced":          {},
+	}
+	validProperties := make(map[string]string)
+	for prop, value := range modifyProperty.Properties {
+		if _, exists := invalidProps[prop]; !exists {
+			validProperties[prop] = value
+		}
+	}
+	return validProperties
 }

--- a/pkg/ccr/record/modify_property.go
+++ b/pkg/ccr/record/modify_property.go
@@ -1,0 +1,35 @@
+package record
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/selectdb/ccr_syncer/pkg/xerror"
+)
+
+type ModifyTableProperty struct {
+	DbId       int64             `json:"dbId"`
+	TableId    int64             `json:"tableId"`
+	TableName  string            `json:"tableName"`
+	Properties map[string]string `json:"properties"`
+	Sql        string            `json:"sql"`
+}
+
+func NewModifyTablePropertyFromJson(data string) (*ModifyTableProperty, error) {
+	var modifyProperty ModifyTableProperty
+	err := json.Unmarshal([]byte(data), &modifyProperty)
+	if err != nil {
+		return nil, xerror.Wrap(err, xerror.Normal, "unmarshal modify table property error")
+	}
+
+	if modifyProperty.TableId == 0 {
+		return nil, xerror.Errorf(xerror.Normal, "table id not found")
+	}
+
+	return &modifyProperty, nil
+}
+
+func (m *ModifyTableProperty) String() string {
+	return fmt.Sprintf("ModifyTableProperty: DbId: %d, TableId: %d, TableName: %s, Properties: %v, Sql: %s",
+		m.DbId, m.TableId, m.TableName, m.Properties, m.Sql)
+}

--- a/regression-test/suites/db_sync/alt_prop/compaction/test_ds_alt_prop_compaction.groovy
+++ b/regression-test/suites/db_sync/alt_prop/compaction/test_ds_alt_prop_compaction.groovy
@@ -121,6 +121,5 @@ suite("test_ds_alt_prop_compaction") {
 
     assertTrue(helper.checkShowTimesOf("SHOW CREATE TABLE ${tableName}", existNewCompaction, 60, "sql"))
 
-    // don't sync
-    assertTrue(helper.checkShowTimesOf("SHOW CREATE TABLE ${tableName}", existOldCompaction, 60, "target"))
+    assertTrue(helper.checkShowTimesOf("SHOW CREATE TABLE ${tableName}", existNewCompaction, 60, "target"))
 }

--- a/regression-test/suites/db_sync/alt_prop/dy_part/test_ds_alt_prop_dy_pary.groovy
+++ b/regression-test/suites/db_sync/alt_prop/dy_part/test_ds_alt_prop_dy_pary.groovy
@@ -108,6 +108,9 @@ suite("test_ds_alt_prop_dy_pary") {
     logger.info("=== Test 2: alter table set property dynamic partition ===")
 
     sql """
+        ALTER TABLE ${tableName} SET ("dynamic_partition.enable" = "true")
+        """
+    sql """
         ALTER TABLE ${tableName} SET ("dynamic_partition.time_unit" = "WEEK")
         """
     sql """
@@ -136,6 +139,11 @@ suite("test_ds_alt_prop_dy_pary") {
 
     assertTrue(helper.checkShowTimesOf("SHOW CREATE TABLE ${tableName}", existNewPartitionProperty, 60, "sql"))
 
-    // don't sync
-    assertTrue(helper.checkShowTimesOf("SHOW CREATE TABLE ${tableName}", existOldPartitionProperty, 60, "target"))
+    assertTrue(helper.checkShowTimesOf("SHOW CREATE TABLE ${tableName}", existNewPartitionProperty, 60, "target"))
+
+    def res = target_sql "SHOW CREATE TABLE ${tableName}"
+    assertTrue(res.contains("\"dynamic_partition.enable\" = \"false\""))
+
+    res = sql "SHOW CREATE TABLE ${tableName}"
+    assertTrue(res.contains("\"dynamic_partition.enable\" = \"true\""))
 }

--- a/regression-test/suites/db_sync/alt_prop/light_schema_change/test_ds_alt_prop_light_schema_change.groovy
+++ b/regression-test/suites/db_sync/alt_prop/light_schema_change/test_ds_alt_prop_light_schema_change.groovy
@@ -85,6 +85,6 @@ suite("test_ds_alt_prop_light_schema_change") {
 
     assertTrue(helper.checkShowTimesOf("SHOW CREATE TABLE ${tableName}", lightSchemaChange, 60, "sql"))
 
-    // todo
+    // don't sync
     assertTrue(helper.checkShowTimesOf("SHOW CREATE TABLE ${tableName}", notLightSchemaChange, 60, "target"))
 }


### PR DESCRIPTION
| 属性 | 是否支持 | 备注 |
|-------|-------|-------|
| colocate_with | 不支持 | backup 过滤了这个属性 |
| distribution type | 不支持 | 操作后无法同步到下游 |
| bucket num | 不支持 | 同上 |
| isBeingSyced | 不支持 | 同上 |
| light_schema_change | 不支持 | 非法的行为 |
| skip_write_index_on_load | 未知 | 此功能暂时被禁用 |
| seq 列 | 不支持 | 不支持修改(建表时指定) |
| delete sign 列 | 不支持 | 不支持修改(default) |
| storage policy | 不支持 | |
| comment | 支持 |  |
| bloom_filter_columns | 支持 |  |
| row_store | 支持 |  |
| compaction 系列属性 | 支持 | |
| dynamic_partition | 支持 | 除了dynamic_partition.enable |

## desc

When set one or more property, automatically skip invalid property. If all properties are invalid, skip binlog


example
```
ALTER TABLE t SET ("dynamic_partition.enable" = "false");
```
```
[2024-12-31 14:32:30.851]  INFO handle modify property binlog, prevCommitSeq: 76503, commitSeq: 76509 job=test line=ccr/job.go:2031
[2024-12-31 14:32:30.854] DEBUG found table 47036 name t job=test line=ccr/meta.go:1026
[2024-12-31 14:32:30.854]  WARN the whole table properties are invalid, skip modify table property job=test line=base/spec.go:1521
```

```
ALTER TABLE t SET ("dynamic_partition.enable" = "false", "dynamic_partition.end"="5", "dynamic_partition.start"="-2")
```
```
[2024-12-31 14:31:21.852]  WARN don't support alter table properties: dynamic_partition.enable job=test line=base/spec.go:1517
[2024-12-31 14:31:21.852]  INFO modify table property sql: ALTER TABLE `db1`.`t` SET ("dynamic_partition.end"="5", "dynamic_partition.start"="-2") job=test line=base/spec.go:1526
[2024-12-31 14:31:21.856] DEBUG job test step next job=test line=ccr/job_progress.go:355
```