### PR TITLE
fix error check in storage_medium test

### DIFF
--- a/regression-test/suites/db_sync/prop_incrsync/storage_medium/test_ds_prop_incrsync_storage_medium.groovy
+++ b/regression-test/suites/db_sync/prop_incrsync/storage_medium/test_ds_prop_incrsync_storage_medium.groovy
@@ -90,8 +90,4 @@ suite("test_ds_prop_incrsync_incsync_storage_medium") {
     assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableNameIncrement}\"", exist, 60, "sql"))
 
     assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableNameIncrement}\"", exist, 60, "target"))
-
-    target_res = target_sql "SHOW CREATE TABLE ${tableNameIncrement}"
-
-    assertTrue(target_res[0][1].contains("\"storage_medium\" = \"ssd\""))
 }


### PR DESCRIPTION
The expected result is table is created successfully without checking the properties