### PR TITLE
fix: db_name should be without double quotation and no '#' comment af…

### DIFF
--- a/shell/db.conf
+++ b/shell/db.conf
@@ -4,4 +4,4 @@ db_host=127.0.0.1
 db_port=3306
 db_user=
 db_password=
-db_name="ccr" # default value
+db_name=ccr


### PR DESCRIPTION
db_type is mysql:
1. if db_name ="ccr" , it will create database which name is **"ccr"** (with double quotation) which failed
2.  if db_name =ccr #xxxx, it will create database which name is **ccr #xxxx**   which failed