### PR TITLE
improvement: Adjust the result of get_lag

### DIFF
--- a/cmd/ccr_syncer/job_collector.go
+++ b/cmd/ccr_syncer/job_collector.go
@@ -140,9 +140,9 @@ func getJobLag(spec *base.Spec, commitSeq int64) (int64, float64, error) {
 	}
 
 	lag := resp.GetLag()
-	firstTimestampMs := resp.GetFirstBinlogTimestamp()
+	nextTimestampMs := resp.GetNextBinlogTimestamp()
 	lastTimestampMs := resp.GetLastBinlogTimestamp()
-	intervals := float64(lastTimestampMs-firstTimestampMs) / 1000.0
+	intervals := float64(lastTimestampMs-nextTimestampMs) / 1000.0
 	if intervals <= 0 || lag <= 0 {
 		intervals = 0
 	}

--- a/pkg/rpc/kitex_gen/frontendservice/FrontendService.go
+++ b/pkg/rpc/kitex_gen/frontendservice/FrontendService.go
@@ -58048,6 +58048,8 @@ type TGetBinlogLagResult_ struct {
 	LastCommitSeq        *int64                 `thrift:"last_commit_seq,5,optional" frugal:"5,optional,i64" json:"last_commit_seq,omitempty"`
 	FirstBinlogTimestamp *int64                 `thrift:"first_binlog_timestamp,6,optional" frugal:"6,optional,i64" json:"first_binlog_timestamp,omitempty"`
 	LastBinlogTimestamp  *int64                 `thrift:"last_binlog_timestamp,7,optional" frugal:"7,optional,i64" json:"last_binlog_timestamp,omitempty"`
+	NextCommitSeq        *int64                 `thrift:"next_commit_seq,8,optional" frugal:"8,optional,i64" json:"next_commit_seq,omitempty"`
+	NextBinlogTimestamp  *int64                 `thrift:"next_binlog_timestamp,9,optional" frugal:"9,optional,i64" json:"next_binlog_timestamp,omitempty"`
 }
 
 func NewTGetBinlogLagResult_() *TGetBinlogLagResult_ {
@@ -58119,6 +58121,24 @@ func (p *TGetBinlogLagResult_) GetLastBinlogTimestamp() (v int64) {
 	}
 	return *p.LastBinlogTimestamp
 }
+
+var TGetBinlogLagResult__NextCommitSeq_DEFAULT int64
+
+func (p *TGetBinlogLagResult_) GetNextCommitSeq() (v int64) {
+	if !p.IsSetNextCommitSeq() {
+		return TGetBinlogLagResult__NextCommitSeq_DEFAULT
+	}
+	return *p.NextCommitSeq
+}
+
+var TGetBinlogLagResult__NextBinlogTimestamp_DEFAULT int64
+
+func (p *TGetBinlogLagResult_) GetNextBinlogTimestamp() (v int64) {
+	if !p.IsSetNextBinlogTimestamp() {
+		return TGetBinlogLagResult__NextBinlogTimestamp_DEFAULT
+	}
+	return *p.NextBinlogTimestamp
+}
 func (p *TGetBinlogLagResult_) SetStatus(val *status.TStatus) {
 	p.Status = val
 }
@@ -58140,6 +58160,12 @@ func (p *TGetBinlogLagResult_) SetFirstBinlogTimestamp(val *int64) {
 func (p *TGetBinlogLagResult_) SetLastBinlogTimestamp(val *int64) {
 	p.LastBinlogTimestamp = val
 }
+func (p *TGetBinlogLagResult_) SetNextCommitSeq(val *int64) {
+	p.NextCommitSeq = val
+}
+func (p *TGetBinlogLagResult_) SetNextBinlogTimestamp(val *int64) {
+	p.NextBinlogTimestamp = val
+}
 
 var fieldIDToName_TGetBinlogLagResult_ = map[int16]string{
 	1: "status",
@@ -58149,6 +58175,8 @@ var fieldIDToName_TGetBinlogLagResult_ = map[int16]string{
 	5: "last_commit_seq",
 	6: "first_binlog_timestamp",
 	7: "last_binlog_timestamp",
+	8: "next_commit_seq",
+	9: "next_binlog_timestamp",
 }
 
 func (p *TGetBinlogLagResult_) IsSetStatus() bool {
@@ -58177,6 +58205,14 @@ func (p *TGetBinlogLagResult_) IsSetFirstBinlogTimestamp() bool {
 
 func (p *TGetBinlogLagResult_) IsSetLastBinlogTimestamp() bool {
 	return p.LastBinlogTimestamp != nil
+}
+
+func (p *TGetBinlogLagResult_) IsSetNextCommitSeq() bool {
+	return p.NextCommitSeq != nil
+}
+
+func (p *TGetBinlogLagResult_) IsSetNextBinlogTimestamp() bool {
+	return p.NextBinlogTimestamp != nil
 }
 
 func (p *TGetBinlogLagResult_) Read(iprot thrift.TProtocol) (err error) {
@@ -58249,6 +58285,22 @@ func (p *TGetBinlogLagResult_) Read(iprot thrift.TProtocol) (err error) {
 		case 7:
 			if fieldTypeId == thrift.I64 {
 				if err = p.ReadField7(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 8:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField8(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 9:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField9(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -58354,6 +58406,28 @@ func (p *TGetBinlogLagResult_) ReadField7(iprot thrift.TProtocol) error {
 	p.LastBinlogTimestamp = _field
 	return nil
 }
+func (p *TGetBinlogLagResult_) ReadField8(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.NextCommitSeq = _field
+	return nil
+}
+func (p *TGetBinlogLagResult_) ReadField9(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.NextBinlogTimestamp = _field
+	return nil
+}
 
 func (p *TGetBinlogLagResult_) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -58387,6 +58461,14 @@ func (p *TGetBinlogLagResult_) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField7(oprot); err != nil {
 			fieldId = 7
+			goto WriteFieldError
+		}
+		if err = p.writeField8(oprot); err != nil {
+			fieldId = 8
+			goto WriteFieldError
+		}
+		if err = p.writeField9(oprot); err != nil {
+			fieldId = 9
 			goto WriteFieldError
 		}
 	}
@@ -58540,6 +58622,44 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 7 end error: ", p), err)
 }
 
+func (p *TGetBinlogLagResult_) writeField8(oprot thrift.TProtocol) (err error) {
+	if p.IsSetNextCommitSeq() {
+		if err = oprot.WriteFieldBegin("next_commit_seq", thrift.I64, 8); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.NextCommitSeq); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 8 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 8 end error: ", p), err)
+}
+
+func (p *TGetBinlogLagResult_) writeField9(oprot thrift.TProtocol) (err error) {
+	if p.IsSetNextBinlogTimestamp() {
+		if err = oprot.WriteFieldBegin("next_binlog_timestamp", thrift.I64, 9); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.NextBinlogTimestamp); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 9 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 9 end error: ", p), err)
+}
+
 func (p *TGetBinlogLagResult_) String() string {
 	if p == nil {
 		return "<nil>"
@@ -58573,6 +58693,12 @@ func (p *TGetBinlogLagResult_) DeepEqual(ano *TGetBinlogLagResult_) bool {
 		return false
 	}
 	if !p.Field7DeepEqual(ano.LastBinlogTimestamp) {
+		return false
+	}
+	if !p.Field8DeepEqual(ano.NextCommitSeq) {
+		return false
+	}
+	if !p.Field9DeepEqual(ano.NextBinlogTimestamp) {
 		return false
 	}
 	return true
@@ -58648,6 +58774,30 @@ func (p *TGetBinlogLagResult_) Field7DeepEqual(src *int64) bool {
 		return false
 	}
 	if *p.LastBinlogTimestamp != *src {
+		return false
+	}
+	return true
+}
+func (p *TGetBinlogLagResult_) Field8DeepEqual(src *int64) bool {
+
+	if p.NextCommitSeq == src {
+		return true
+	} else if p.NextCommitSeq == nil || src == nil {
+		return false
+	}
+	if *p.NextCommitSeq != *src {
+		return false
+	}
+	return true
+}
+func (p *TGetBinlogLagResult_) Field9DeepEqual(src *int64) bool {
+
+	if p.NextBinlogTimestamp == src {
+		return true
+	} else if p.NextBinlogTimestamp == nil || src == nil {
+		return false
+	}
+	if *p.NextBinlogTimestamp != *src {
 		return false
 	}
 	return true

--- a/pkg/rpc/kitex_gen/frontendservice/k-FrontendService.go
+++ b/pkg/rpc/kitex_gen/frontendservice/k-FrontendService.go
@@ -42060,6 +42060,34 @@ func (p *TGetBinlogLagResult_) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 8:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField8(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 9:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField9(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -42186,6 +42214,32 @@ func (p *TGetBinlogLagResult_) FastReadField7(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *TGetBinlogLagResult_) FastReadField8(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.NextCommitSeq = &v
+
+	}
+	return offset, nil
+}
+
+func (p *TGetBinlogLagResult_) FastReadField9(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.NextBinlogTimestamp = &v
+
+	}
+	return offset, nil
+}
+
 // for compatibility
 func (p *TGetBinlogLagResult_) FastWrite(buf []byte) int {
 	return 0
@@ -42200,6 +42254,8 @@ func (p *TGetBinlogLagResult_) FastWriteNocopy(buf []byte, binaryWriter bthrift.
 		offset += p.fastWriteField5(buf[offset:], binaryWriter)
 		offset += p.fastWriteField6(buf[offset:], binaryWriter)
 		offset += p.fastWriteField7(buf[offset:], binaryWriter)
+		offset += p.fastWriteField8(buf[offset:], binaryWriter)
+		offset += p.fastWriteField9(buf[offset:], binaryWriter)
 		offset += p.fastWriteField1(buf[offset:], binaryWriter)
 		offset += p.fastWriteField3(buf[offset:], binaryWriter)
 	}
@@ -42219,6 +42275,8 @@ func (p *TGetBinlogLagResult_) BLength() int {
 		l += p.field5Length()
 		l += p.field6Length()
 		l += p.field7Length()
+		l += p.field8Length()
+		l += p.field9Length()
 	}
 	l += bthrift.Binary.FieldStopLength()
 	l += bthrift.Binary.StructEndLength()
@@ -42300,6 +42358,28 @@ func (p *TGetBinlogLagResult_) fastWriteField7(buf []byte, binaryWriter bthrift.
 	return offset
 }
 
+func (p *TGetBinlogLagResult_) fastWriteField8(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetNextCommitSeq() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "next_commit_seq", thrift.I64, 8)
+		offset += bthrift.Binary.WriteI64(buf[offset:], *p.NextCommitSeq)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetBinlogLagResult_) fastWriteField9(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetNextBinlogTimestamp() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "next_binlog_timestamp", thrift.I64, 9)
+		offset += bthrift.Binary.WriteI64(buf[offset:], *p.NextBinlogTimestamp)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
 func (p *TGetBinlogLagResult_) field1Length() int {
 	l := 0
 	if p.IsSetStatus() {
@@ -42369,6 +42449,28 @@ func (p *TGetBinlogLagResult_) field7Length() int {
 	if p.IsSetLastBinlogTimestamp() {
 		l += bthrift.Binary.FieldBeginLength("last_binlog_timestamp", thrift.I64, 7)
 		l += bthrift.Binary.I64Length(*p.LastBinlogTimestamp)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetBinlogLagResult_) field8Length() int {
+	l := 0
+	if p.IsSetNextCommitSeq() {
+		l += bthrift.Binary.FieldBeginLength("next_commit_seq", thrift.I64, 8)
+		l += bthrift.Binary.I64Length(*p.NextCommitSeq)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetBinlogLagResult_) field9Length() int {
+	l := 0
+	if p.IsSetNextBinlogTimestamp() {
+		l += bthrift.Binary.FieldBeginLength("next_binlog_timestamp", thrift.I64, 9)
+		l += bthrift.Binary.I64Length(*p.NextBinlogTimestamp)
 
 		l += bthrift.Binary.FieldEndLength()
 	}

--- a/pkg/rpc/thrift/FrontendService.thrift
+++ b/pkg/rpc/thrift/FrontendService.thrift
@@ -1282,6 +1282,8 @@ struct TGetBinlogLagResult {
     5: optional i64 last_commit_seq
     6: optional i64 first_binlog_timestamp
     7: optional i64 last_binlog_timestamp
+    8: optional i64 next_commit_seq
+    9: optional i64 next_binlog_timestamp
 }
 
 struct TUpdateFollowerStatsCacheRequest {

--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -230,6 +230,8 @@ func (s *HttpService) getLagHandler(w http.ResponseWriter, r *http.Request) {
 		FirstBinlogTimestamp string  `json:"first_binlog_timestamp"`
 		LastBinlogTimestamp  string  `json:"last_binlog_timestamp"`
 		TimeInterval         float64 `json:"time_interval_secs"`
+		NextCommitSeq        int64   `json:"next_commit_seq"`
+		NextBinlogTimestamp  string  `json:"next_binlog_timestamp"`
 	}
 	var lagResult *result
 	defer func() { writeJson(w, lagResult) }()
@@ -317,20 +319,26 @@ func (s *HttpService) getLagHandler(w http.ResponseWriter, r *http.Request) {
 	lag := resp.GetLag()
 	firstCommitSeq := resp.GetFirstCommitSeq()
 	lastCommitSeq := resp.GetLastCommitSeq()
-	var firstBinlogTimestamp, lastBinlogTimestamp string
+	nextCommitSeq := resp.GetNextCommitSeq()
+	var nextBinlogTimestamp, lastBinlogTimestamp, firstBinlogTimestamp string
 
-	if ts := resp.GetFirstBinlogTimestamp(); ts != -1 {
-		firstBinlogTimestamp = ConvertTimestampToString(resp.GetFirstBinlogTimestamp())
+	if ts := resp.GetNextBinlogTimestamp(); ts != -1 {
+		nextBinlogTimestamp = ConvertTimestampToString(ts)
 	} else {
-		firstBinlogTimestamp = "1970-01-01 08:00:00"
+		nextBinlogTimestamp = "1970-01-01 08:00:00"
 	}
 	if ts := resp.GetLastBinlogTimestamp(); ts != -1 {
-		lastBinlogTimestamp = ConvertTimestampToString(resp.GetLastBinlogTimestamp())
+		lastBinlogTimestamp = ConvertTimestampToString(ts)
 	} else {
 		lastBinlogTimestamp = "1970-01-01 08:00:00"
 	}
+	if ts := resp.GetFirstBinlogTimestamp(); ts != -1 {
+		firstBinlogTimestamp = ConvertTimestampToString(ts)
+	} else {
+		firstBinlogTimestamp = "1970-01-01 08:00:00"
+	}
 
-	timeInterval := CalculateTimeDifferenceInSeconds(lastBinlogTimestamp, firstBinlogTimestamp)
+	timeInterval := CalculateTimeDifferenceInSeconds(lastBinlogTimestamp, nextBinlogTimestamp)
 
 	lagResult = &result{
 		defaultResult:        newSuccessResult(),
@@ -340,6 +348,8 @@ func (s *HttpService) getLagHandler(w http.ResponseWriter, r *http.Request) {
 		FirstBinlogTimestamp: firstBinlogTimestamp,
 		LastBinlogTimestamp:  lastBinlogTimestamp,
 		TimeInterval:         timeInterval,
+		NextCommitSeq:        nextCommitSeq,
+		NextBinlogTimestamp:  nextBinlogTimestamp,
 	}
 }
 

--- a/regression-test/suites/syncer/get_lag/test_syncer_get_lag.groovy
+++ b/regression-test/suites/syncer/get_lag/test_syncer_get_lag.groovy
@@ -47,11 +47,13 @@ suite("test_syncer_get_lag") {
     def validateLagData = { lag ->
         assertTrue(lag != null)
         assertTrue(lag.containsKey("lag"))
-        assertTrue(lag.containsKey("first_commit_seq"))
+        assertTrue(lag.containsKey("next_commit_seq"))
         assertTrue(lag.containsKey("last_commit_seq"))
         assertTrue(lag.containsKey("first_binlog_timestamp"))
         assertTrue(lag.containsKey("last_binlog_timestamp"))
+        assertTrue(lag.containsKey("next_binlog_timestamp"))
         assertTrue(lag.containsKey("time_interval_secs"))
+        assertTrue(lag.containsKey("first_commit_seq"))
         assertTrue(lag.lag >= 0)
     }
     
@@ -59,7 +61,7 @@ suite("test_syncer_get_lag") {
     logger.info("Initial lag info: ${initialLag}")
     
     validateLagData(initialLag)
-    Boolean res = initialLag.last_commit_seq - initialLag.first_commit_seq <= 1
+    Boolean res = initialLag.last_commit_seq - initialLag.next_commit_seq <= 1
     assertTrue(res);
 
     {
@@ -106,7 +108,7 @@ suite("test_syncer_get_lag") {
         
         validateLagData(lagAfterMoreData)
         
-        if (lagAfterPause.first_commit_seq == lagAfterMoreData.first_commit_seq) {
+        if (lagAfterPause.next_commit_seq == lagAfterMoreData.next_commit_seq) {
             assertTrue(lagAfterMoreData.lag >= lagAfterPause.lag)
         }
     }
@@ -129,7 +131,7 @@ suite("test_syncer_get_lag") {
         
         validateLagData(lagAfterResume)
         
-        if (lagAfterResume.first_commit_seq >= lagAfterResumeImmediate.first_commit_seq) {
+        if (lagAfterResume.next_commit_seq >= lagAfterResumeImmediate.next_commit_seq) {
             res = lagAfterResume.lag <= lagAfterResumeImmediate.lag || lagAfterResume.lag == 0
             assertTrue(res == true);
         }
@@ -158,8 +160,8 @@ suite("test_syncer_get_lag") {
         
         validateLagData(lagAfterSync)
         
-        if (lagAfterSync.first_binlog_timestamp && lagAfterSync.last_binlog_timestamp && 
-            !lagAfterSync.first_binlog_timestamp.isEmpty() && !lagAfterSync.last_binlog_timestamp.isEmpty()) {
+        if (lagAfterSync.next_binlog_timestamp && lagAfterSync.last_binlog_timestamp && 
+            !lagAfterSync.next_binlog_timestamp.isEmpty() && !lagAfterSync.last_binlog_timestamp.isEmpty()) {
             
             assertTrue(lagAfterSync.time_interval_secs >= 0)
         }
@@ -181,7 +183,7 @@ suite("test_syncer_get_lag") {
         validateLagData(lagAfterDesync)
         
         afterRowCount =  target_sql """ select * FROM ${tableName} """
-        assertEquals(initialRowCount, afterRowCount)
+        assertEquals(initialRowCount.size(), afterRowCount.size())
         
         helper.ccrJobSync(tableName)
         
@@ -219,5 +221,105 @@ suite("test_syncer_get_lag") {
         def finalLag = helper.get_job_lag(tableName)
         logger.info("Final lag after rapid operations: ${finalLag}")
         validateLagData(finalLag)
+    }
+
+    {
+        
+        def recycleTableName = "t_lag_recycle_" + helper.randomSuffix()
+        
+        sql """ DROP TABLE IF EXISTS ${recycleTableName} """
+        target_sql """DROP TABLE IF EXISTS ${recycleTableName}"""
+        
+        sql """
+            CREATE TABLE ${recycleTableName} (
+                id INT,
+                name VARCHAR(50),
+                value DOUBLE
+            )
+            DISTRIBUTED BY HASH(id) BUCKETS 3
+            PROPERTIES(
+                "replication_num" = "1"
+            )
+        """
+        
+        helper.enableDbBinlog()
+        
+        helper.ccrJobCreate(recycleTableName)
+        assertTrue(helper.checkRestoreFinishTimesOf("${recycleTableName}", 60))
+        
+        sql """
+            INSERT INTO ${recycleTableName} VALUES (1, 'initial', 1.1), (2, 'initial', 2.2)
+        """
+        
+        def initialRecycleLag = helper.get_job_lag(recycleTableName)
+        logger.info("Initial lag info for recycle test: ${initialRecycleLag}")
+        validateLagData(initialRecycleLag)
+        def prevRecycleSeq = initialRecycleLag.last_commit_seq
+        logger.info("Previous commit sequence for recycle test: ${prevRecycleSeq}")
+        
+        assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${recycleTableName}", 2, 10))
+        
+        logger.info("Disabling database binlog to simulate recycling...")
+        sql """
+            ALTER DATABASE ${context.dbName} SET PROPERTIES("binlog.enable" = "false")
+        """
+        
+        sleep(3000)
+        
+        def checkBinlogDisabled = sql """
+            SHOW CREATE DATABASE ${context.dbName}
+        """
+        logger.info("Database properties after disabling binlog: ${checkBinlogDisabled}")
+        
+        sql """
+            INSERT INTO ${recycleTableName} VALUES (3, 'no_binlog', 3.3), (4, 'no_binlog', 4.4)
+        """
+        
+        sleep(2000)
+        
+        def lagWhileDisabled = helper.get_job_lag(recycleTableName)
+        validateLagData(lagWhileDisabled)
+        
+        logger.info("Dropping and recreating table to force binlog sequence reset...")
+        sql """ DROP TABLE IF EXISTS ${recycleTableName} """
+        
+        sql """
+            ALTER DATABASE ${context.dbName} SET PROPERTIES("binlog.enable" = "true")
+        """
+        
+        sleep(3000)
+        
+        sql """
+            CREATE TABLE ${recycleTableName} (
+                id INT,
+                name VARCHAR(50),
+                value DOUBLE
+            )
+            DISTRIBUTED BY HASH(id) BUCKETS 3
+            PROPERTIES(
+                "replication_num" = "1", 
+                "binlog.enable" = "true"
+            )
+        """
+        
+        sql """
+            INSERT INTO ${recycleTableName} VALUES (5, 'new_binlog', 5.5), (6, 'new_binlog', 6.6)
+        """
+        
+        sleep(3000)
+        
+        def lagAfterReset = helper.get_job_lag(recycleTableName)
+        logger.info("Lag info after table reset: ${lagAfterReset}")
+        validateLagData(lagAfterReset)
+        
+        def newNextCommitSeq = lagAfterReset.next_commit_seq
+        logger.info("New next commit sequence after recycling: ${newNextCommitSeq}")
+        logger.info("Previous last commit sequence: ${prevRecycleSeq}")
+        logger.info("Testing if nextBinlog.getCommitSeq() > prevCommitSeq: ${newNextCommitSeq} > ${prevRecycleSeq}")
+        
+        assertTrue(newNextCommitSeq > prevRecycleSeq, 
+            "Expected next commit sequence (${newNextCommitSeq}) to be greater than previous sequence (${prevRecycleSeq})")
+        
+        assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${recycleTableName}", 4, 10))
     }
 }


### PR DESCRIPTION
Add info `nextCommitSeq` for get_lag
Return the appropriate result of `firstCommitSeq` and `lastCommitSeq`

```
2025-03-13 14:42:36.666 INFO [suite-thread-1] (helper.groovy:273) - job lag info: [success:true, lag:0, first_commit_seq:-1, last_commit_seq:36949, first_binlog_timestamp:2025-03-13 14:41:41, last_binlog_timestamp:2025-03-13 14:42:28, time_interval_secs:0, next_commit_seq:36949, next_binlog_timestamp:2025-03-13 14:42:28]
2025-03-13 14:42:36.667 INFO [suite-thread-1] (test_syncer_get_lag.groovy:312) - Lag info after table reset: [success:true, lag:0, first_commit_seq:-1, last_commit_seq:36949, first_binlog_timestamp:2025-03-13 14:41:41, last_binlog_timestamp:2025-03-13 14:42:28, time_interval_secs:0, next_commit_seq:36949, next_binlog_timestamp:2025-03-13 14:42:28]
2025-03-13 14:42:36.667 INFO [suite-thread-1] (test_syncer_get_lag.groovy:316) - New next commit sequence after recycling: 36949
2025-03-13 14:42:36.668 INFO [suite-thread-1] (test_syncer_get_lag.groovy:317) - Previous last commit sequence: 36936
2025-03-13 14:42:36.668 INFO [suite-thread-1] (test_syncer_get_lag.groovy:318) - Testing if nextBinlog.getCommitSeq() > prevCommitSeq: 36949 > 36936

```