### PR TITLE
fix: Wait prev txn publish before handle not upsert binlog

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -1742,6 +1742,7 @@ func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 		log.Debugf("txn %d committed, commitSeq: %d, cleanup", inMemoryData.TxnId, j.progress.CommitSeq)
 		commitSeq := j.progress.CommitSeq
 		destTableIds := inMemoryData.DestTableIds
+		j.progress.PrevTxnId = inMemoryData.TxnId
 		if j.SyncType == DBSync && len(j.progress.TableCommitSeqMap) > 0 {
 			for _, tableId := range destTableIds {
 				tableCommitSeq, ok := j.progress.TableCommitSeqMap[tableId]
@@ -3446,6 +3447,13 @@ func (j *Job) handleNonBarrierBinlog(binlog *festruct.TBinlog) error {
 
 	if binlogType == festruct.TBinlogType_UPSERT {
 		return j.handleUpsertWithRetry(binlog)
+	}
+
+	if prevTxnId := j.progress.PrevTxnId; prevTxnId != -1 {
+		dest := &j.Dest
+		log.Infof("wait prev txn id: %d published", prevTxnId)
+		dest.WaitTransactionDone(prevTxnId)
+		j.progress.PrevTxnId = -1
 	}
 
 	// handle ddl binlog

--- a/pkg/ccr/job_progress.go
+++ b/pkg/ccr/job_progress.go
@@ -188,6 +188,7 @@ type JobProgress struct {
 
 	// The tables need to be replaced rather than dropped during sync.
 	TableAliases map[string]string `json:"table_aliases,omitempty"`
+	PrevTxnId    int64             `json:"prev_txn_id,omitempty"`
 
 	// The shadow indexes of the pending schema changes
 	ShadowIndexes map[int64]int64 `json:"shadow_index_map,omitempty"`
@@ -246,6 +247,7 @@ func NewJobProgress(jobName string, syncType SyncType, db storage.DB) *JobProgre
 		FullSyncStartAt:        0,
 		IncrementalSyncStartAt: 0,
 		IngestBinlogAt:         0,
+		PrevTxnId:              -1,
 	}
 }
 


### PR DESCRIPTION
```
[2025-04-02 17:12:39.458]  INFO commit txn 3033 success job=test_ds_dep_part_drop line=ccr/job.go:1989
[2025-04-02 17:12:39.458] DEBUG txn 3033 committed, commitSeq: 31480, cleanup job=test_ds_dep_part_drop line=ccr/job.go:1742
[2025-04-02 17:12:39.458] DEBUG job test_ds_dep_part_drop step next, sync state: DBIncrementalSync, commitSeq: 31480, prevCommitSeq: 31476 job=test_ds_dep_part_drop line=ccr/job_progress.go:381
[2025-04-02 17:12:39.459] DEBUG binlog type: DROP_PARTITION, commit seq: 31483, binlog data: {"dbId":1743474134165,"tableId":1743585041873,"pid":1743585041870,"partitionName":"p1","isTempPartition":false,"forceDrop":false,"recycleTime":1743585154491,"sql":"DROP PARTITION `p1`","version":12,"versionTime":1743585154491} job=test_ds_dep_part_drop line=ccr/job.go:3419
[2025-04-02 17:12:39.460]  INFO wait prev txn id: 3033 published job=test_ds_dep_part_drop line=ccr/job.go:3454
[2025-04-02 17:12:39.460] DEBUG wait transaction done sql: SHOW TRANSACTION FROM `TEST_regression_test_ccr_test` WHERE id = 3033 job=test_ds_dep_part_drop line=base/spec.go:1104
[2025-04-02 17:12:39.478] DEBUG check transaction 3033 status: [VISIBLE] job=test_ds_dep_part_drop line=base/spec.go:1123
[2025-04-02 17:12:39.481] DEBUG found table 1743585041917 name tbl_38985931_0 job=test_ds_dep_part_drop line=ccr/meta.go:1080
[2025-04-02 17:12:39.481]  INFO drop partition sql: ALTER TABLE `TEST_regression_test_ccr_test`.`tbl_38985931_0` DROP PARTITION IF EXISTS `p1`  job=test_ds_dep_part_drop line=base/spec.go:1370
[2025-04-02 17:12:39.486] DEBUG job test_ds_dep_part_drop step next, sync state: DBIncrementalSync, commitSeq: 31483, prevCommitSeq: 31480 job=test_ds_dep_part_drop line=ccr/job_progress.go:381
```