### PR TITLE
fix: fix upsert handle dropped table generate mapping

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -933,6 +933,7 @@ func (j *Job) fullSync() error {
 		if err := j.ISrc.CreateSnapshot(snapshotName, backupTableList); err != nil {
 			return err
 		}
+		utils.SetDebugPoint("fullsync create snapshot")
 		j.progress.NextSubVolatile(WaitBackupDone, snapshotName)
 		return nil
 
@@ -1366,11 +1367,6 @@ func (j *Job) fullSync() error {
 				tableMapping[srcTableId] = destTableId
 			}
 
-			// srcMeta may cache tables that have been dropped (created with the same name after being dropped after the fullsync 1.2 step)
-			// and these tables, if there is an upsert binlog processed after fullsync
-			// will result in a mapping between these dropped tables and the new table with the same name in the downstream mapping table
-			// i.e., the TableMapping generates an error log, so that if there is a drop table binlog after the upsert
-			// then the new table with the same name will be dropped by the error
 			j.srcMeta.ClearTablesCache()
 			j.progress.TableMapping = tableMapping
 			j.progress.ShadowIndexes = nil
@@ -1546,6 +1542,14 @@ func (j *Job) getDbSyncTableRecords(upsert *record.Upsert) []*record.TableRecord
 	tableRecords := make([]*record.TableRecord, 0, len(upsert.TableRecords))
 
 	for tableId, tableRecord := range upsert.TableRecords {
+		// filter dropped table on upstream
+		if ok, err := j.isTableDropped(tableId); err != nil {
+			log.Warn(err)
+			return nil
+		} else if ok {
+			log.Warn("table dropped on upstream")
+			continue
+		}
 		if tableCommitSeq, ok := tableCommitSeqMap[tableId]; ok && commitSeq <= tableCommitSeq {
 			// All the partition records of the table have been committed
 			continue
@@ -1567,7 +1571,7 @@ func (j *Job) getDbSyncTableRecords(upsert *record.Upsert) []*record.TableRecord
 			tableRecords = append(tableRecords, tableRecord)
 		}
 	}
-
+	log.Debug(tableRecords)
 	return tableRecords
 }
 

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -1366,6 +1366,12 @@ func (j *Job) fullSync() error {
 				tableMapping[srcTableId] = destTableId
 			}
 
+			// srcMeta may cache tables that have been dropped (created with the same name after being dropped after the fullsync 1.2 step)
+			// and these tables, if there is an upsert binlog processed after fullsync
+			// will result in a mapping between these dropped tables and the new table with the same name in the downstream mapping table
+			// i.e., the TableMapping generates an error log, so that if there is a drop table binlog after the upsert
+			// then the new table with the same name will be dropped by the error
+			j.srcMeta.ClearTablesCache()
 			j.progress.TableMapping = tableMapping
 			j.progress.ShadowIndexes = nil
 			j.progress.PartitionCommitSeqMap = nil

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -1571,7 +1571,6 @@ func (j *Job) getDbSyncTableRecords(upsert *record.Upsert) []*record.TableRecord
 			tableRecords = append(tableRecords, tableRecord)
 		}
 	}
-	log.Debug(tableRecords)
 	return tableRecords
 }
 

--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -927,6 +927,64 @@ func (s *HttpService) failpointHandler(w http.ResponseWriter, r *http.Request) {
 	result = newSuccessResult()
 }
 
+func (s *HttpService) debugpointHandler(w http.ResponseWriter, r *http.Request) {
+	log.Infof("debugpoint")
+
+	var result *defaultResult
+	defer func() { writeJson(w, result) }()
+
+	// Parse the JSON request body
+	var request struct {
+		Name     string `json:"name"` // the debug point name
+		Operator string `json:"op"`
+	}
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		log.Warnf("parse debug failed: %+v", err)
+		result = newErrorResult(err.Error())
+		return
+	}
+
+	if request.Operator == "enable" {
+		utils.EnableDebugpoint()
+		result = newSuccessResult()
+		return
+	} else if request.Operator == "disable" {
+		utils.DisableDebugpoint()
+		result = newSuccessResult()
+		return
+	}
+
+	if ok := utils.IsDebugpointEnabled(); !ok {
+		log.Warnf("debug point not enable")
+		result = newErrorResult("debug point not enable")
+		return
+	}
+
+	if request.Name == "" {
+		log.Warnf("debug point name is empty")
+		result = newErrorResult("debug point name is empty")
+		return
+	} else if request.Operator != "" {
+		switch request.Operator {
+		case "open":
+			utils.OpenDebugPoint(request.Name)
+		case "close":
+			utils.CloseDebugPoint(request.Name)
+		default:
+			log.Info("unknow operator")
+			result = newErrorResult("unknow operator")
+			return
+		}
+	} else {
+		log.Info("dont have any operator")
+		result = newErrorResult("dont have any operator")
+		return
+	}
+
+	result = newSuccessResult()
+}
+
 func (s *HttpService) RegisterHandlers() {
 	s.mux.HandleFunc("/version", s.versionHandler)
 	s.mux.HandleFunc("/create_ccr", s.createHandler)
@@ -944,6 +1002,7 @@ func (s *HttpService) RegisterHandlers() {
 	s.mux.HandleFunc("/update_host_mapping", s.updateHostMappingHandler)
 	s.mux.HandleFunc("/job_skip_binlog", s.skipBinlogHandler)
 	s.mux.HandleFunc("/failpoint", s.failpointHandler)
+	s.mux.HandleFunc("/debugpoint", s.debugpointHandler)
 	s.mux.Handle("/metrics", xmetrics.GetHttpHandler())
 	s.mux.HandleFunc("/sync", s.syncHandler)
 }

--- a/pkg/utils/debugpoint.go
+++ b/pkg/utils/debugpoint.go
@@ -49,12 +49,8 @@ func SetDebugPoint(name string) {
 	if !IsDebugpointEnabled() || !Debugpointexists(name) {
 		return
 	}
-	for {
-		if v, _ := debugpoints.Load(name); v == true {
-			time.Sleep(time.Microsecond)
-		} else {
-			return
-		}
+	for v, _ := debugpoints.Load(name); v == true; {
+		time.Sleep(time.Microsecond)
 	}
 }
 

--- a/pkg/utils/debugpoint.go
+++ b/pkg/utils/debugpoint.go
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License
+package utils
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	debugpointEnabled = atomic.Bool{}
+	debugpoints       = sync.Map{}
+)
+
+func IsDebugpointEnabled() bool {
+	return debugpointEnabled.Load()
+}
+
+func EnableDebugpoint() {
+	debugpointEnabled.Store(true)
+}
+
+func DisableDebugpoint() {
+	debugpointEnabled.Store(false)
+}
+
+func Debugpointexists(name string) bool {
+	_, ok := debugpoints.Load(name)
+	return ok
+}
+
+// for program set a point and wait it close
+func SetDebugPoint(name string) {
+	if !IsDebugpointEnabled() || !Debugpointexists(name) {
+		return
+	}
+	for {
+		if v, _ := debugpoints.Load(name); v == true {
+			time.Sleep(time.Microsecond)
+		} else {
+			return
+		}
+	}
+}
+
+func OpenDebugPoint(name string) {
+	debugpoints.Store(name, true)
+}
+
+func CloseDebugPoint(name string) {
+	debugpoints.Store(name, false)
+}

--- a/regression-test/common/helper.groovy
+++ b/regression-test/common/helper.groovy
@@ -664,6 +664,118 @@ class Helper {
         }
     }
 
+    void enableDebugpoint() {
+        def gson = new com.google.gson.Gson()
+        def request_body = [
+            name: "",
+            op: "enable",
+        ]
+        def enable_debugpoint_uri = { check_func ->
+            suite.httpTest {
+                uri "/debugpoint"
+                endpoint syncerAddress
+                body gson.toJson(request_body)
+                op "post"
+                check check_func
+            }
+        }
+
+        enable_debugpoint_uri.call() { code, body ->
+            if (!"${code}".toString().equals("200")) {
+                throw "request failed, code: ${code}, body: ${body}"
+            }
+            def jsonSlurper = new groovy.json.JsonSlurper()
+            def object = jsonSlurper.parseText "${body}"
+            if (!object.success) {
+                throw "request failed, error msg: ${object.error_msg}"
+            }
+        }
+    }
+
+    void disableDebugpoint() {
+        def gson = new com.google.gson.Gson()
+        def request_body = [
+            name: "",
+            op: "disable",
+        ]
+        def disable_debugpoint_uri = { check_func ->
+            suite.httpTest {
+                uri "/debugpoint"
+                endpoint syncerAddress
+                body gson.toJson(request_body)
+                op "post"
+                check check_func
+            }
+        }
+
+        disable_debugpoint_uri.call() { code, body ->
+            if (!"${code}".toString().equals("200")) {
+                throw "request failed, code: ${code}, body: ${body}"
+            }
+            def jsonSlurper = new groovy.json.JsonSlurper()
+            def object = jsonSlurper.parseText "${body}"
+            if (!object.success) {
+                throw "request failed, error msg: ${object.error_msg}"
+            }
+        }
+    }
+
+    void openDebugpoint(String name) {
+        def gson = new com.google.gson.Gson()
+        def request_body = [
+            name: name,
+            op: "open",
+        ]
+        def open_debugpoint_uri = { check_func ->
+            suite.httpTest {
+                uri "/debugpoint"
+                endpoint syncerAddress
+                body gson.toJson(request_body)
+                op "post"
+                check check_func
+            }
+        }
+
+        open_debugpoint_uri.call() { code, body ->
+            if (!"${code}".toString().equals("200")) {
+                throw "request failed, code: ${code}, body: ${body}"
+            }
+            def jsonSlurper = new groovy.json.JsonSlurper()
+            def object = jsonSlurper.parseText "${body}"
+            if (!object.success) {
+                throw "request failed, error msg: ${object.error_msg}"
+            }
+        }
+    }
+
+    void closeDebugpoint(String name) {
+        def gson = new com.google.gson.Gson()
+        def request_body = [
+            name: name,
+            op: "close",
+        ]
+        def close_debugpoint_uri = { check_func ->
+            suite.httpTest {
+                uri "/debugpoint"
+                endpoint syncerAddress
+                body gson.toJson(request_body)
+                op "post"
+                check check_func
+            }
+        }
+
+        close_debugpoint_uri.call() { code, body ->
+            if (!"${code}".toString().equals("200")) {
+                throw "request failed, code: ${code}, body: ${body}"
+            }
+            def jsonSlurper = new groovy.json.JsonSlurper()
+            def object = jsonSlurper.parseText "${body}"
+            if (!object.success) {
+                throw "request failed, error msg: ${object.error_msg}"
+            }
+        }
+    }
+
     void removeFailpoint(String failpoint, String tableName = "") {
         addFailpoint(failpoint, null, tableName)
     }

--- a/regression-test/suites/cross_ds/fullsync/upsert_drop_cre/test_cds_upsert_drop_create.groovy
+++ b/regression-test/suites/cross_ds/fullsync/upsert_drop_cre/test_cds_upsert_drop_create.groovy
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_cds_upsert_drop_create", "nonConcurrent") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    def tableName = "tbl_" + helper.randomSuffix()
+    def test_num = 0
+    def insert_num = 10
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+    def notExist = { res -> Boolean
+        return res.size() == 0
+    }
+
+    try {
+        GetDebugPoint().enableDebugPointForAllFEs("BackupHandler.backup.block")
+        helper.enableDebugpoint()
+        helper.enableDbBinlog()
+
+        sql """
+            CREATE TABLE if NOT EXISTS ${tableName}
+            (
+                `test` INT,
+                `id` INT
+            )
+            ENGINE=OLAP
+            UNIQUE KEY(`test`, `id`)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES (
+                "replication_allocation" = "tag.location.default: 1",
+                "binlog.enable" = "true"
+            )
+        """
+
+        helper.ccrJobDelete()
+        assertTrue(helper.checkShowTimesOf(""" SHOW TABLES LIKE "${tableName}" """, exist, 60, "sql"))
+        helper.openDebugpoint("fullsync create snapshot")
+        helper.ccrJobCreate()    
+
+        sleep(5000)
+
+        sql """
+            INSERT INTO ${tableName} VALUES (1, 1)
+            """
+
+        sql "DROP TABLE ${tableName} FORCE"
+
+        sql """
+            CREATE TABLE if NOT EXISTS ${tableName}
+            (
+                `test` INT,
+                `id` INT
+            )
+            ENGINE=OLAP
+            UNIQUE KEY(`test`, `id`)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES (
+                "replication_allocation" = "tag.location.default: 1",
+                "binlog.enable" = "true"
+            )
+        """
+
+        GetDebugPoint().clearDebugPointsForAllFEs()
+        helper.closeDebugpoint("fullsync create snapshot")
+
+        assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 180))
+        assertTrue(helper.checkShowTimesOf(""" SHOW TABLES LIKE "${tableName}" """, exist, 60, "target"))
+
+        sql """
+            INSERT INTO ${tableName} VALUES (1, 1)
+            """
+
+        assertTrue(helper.checkShowTimesOf(""" select * from ${tableName} """, { r -> r.size() == 1}, 60, "target"))
+    } catch(Exception e) {
+        logger.info(e.getMessage())
+        throw e
+    } finally {
+        GetDebugPoint().clearDebugPointsForAllFEs()
+        helper.closeDebugpoint("fullsync create snapshot")
+        helper.disableDebugpoint()
+    }
+}


### PR DESCRIPTION
Case：
Create table test              seq:1
Insert Values into test     seq:2
Drop table test                 seq:3
Create table test              seq:4

If fullsync is triggered, the final state is seq4, but replay operations 2,3,4, then in 2 that is, when handleupsert in j.GetDestTableIdBySrc(tableRecord.Id) will be in the TableMapping will be recorded in the Tableold has been dropped tableold test and new test in the downstream mapping of the table mapping relationship between the table, after the drop table will not be able to filter out the drop of the old table binlog, ultimately leading to the downstream table was incorrectly deleted

case depend https://github.com/apache/doris/pull/50380