### PR TITLE
test: apply add rollup before upsert to avoid full sync

### DIFF
--- a/regression-test/suites/cross_ds/upsert_index/test_cds_upsert_index.groovy
+++ b/regression-test/suites/cross_ds/upsert_index/test_cds_upsert_index.groovy
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_cds_upsert_index") {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", "helper.groovy"))
+
+    def tableName = "tbl_" + helper.randomSuffix()
+
+    def exist = { res -> Boolean
+        return res.size() != 0
+    }
+
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    target_sql "DROP TABLE IF EXISTS ${tableName}"
+
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName} 
+        (
+            `id` INT,
+            `col1` INT,
+            `col2` INT,
+            `col3` INT,
+            `col4` INT,
+        )
+        ENGINE=OLAP
+        DISTRIBUTED BY HASH(id) BUCKETS 1 
+        PROPERTIES ( 
+            "replication_allocation" = "tag.location.default: 1"
+        )
+    """
+
+    helper.enableDbBinlog()
+    helper.ccrJobDelete()
+    helper.ccrJobCreate()
+
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 30))
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName}\"", exist, 60, "sql"))
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName}\"", exist, 60, "target"))
+
+    def first_job_progress = helper.get_job_progress()
+
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+
+    sql """
+        CREATE MATERIALIZED VIEW mtr_${tableName}_full AS
+        SELECT col1, col3 FROM ${tableName}
+        """
+
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+    sql """ INSERT INTO ${tableName} VALUES (1, 1, 1, 1, 1) """
+
+    assertTrue(helper.checkShowTimesOf("SELECT count(*) FROM ${tableName}", { r -> r[0][0] = 20 }, 60, "target"))
+
+    def checkViewExists = { res -> Boolean
+        for (List<Object> row : res) {
+            if ((row[1] as String).contains("mtr_${tableName}_full")) {
+                return true
+            }
+        }
+        return false
+    }
+    assertTrue(helper.checkShowTimesOf("""
+                                SHOW CREATE MATERIALIZED VIEW mtr_${tableName}_full
+                                ON ${tableName}
+                                """,
+                                checkViewExists, 30, "target"))
+
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", 20, 50))
+
+    def last_job_progress = helper.get_job_progress()
+    assertTrue(last_job_progress.full_sync_start_at == first_job_progress.full_sync_start_at)
+}
+


### PR DESCRIPTION
doris: https://github.com/apache/doris/pull/50337

now, upsert will skip the rollup index that will be added
```
[2025-04-23 22:40:53.425] DEBUG binlog type: ALTER_JOB, commit seq: 7665, binlog data: {"type":"ROLLUP","dbId":1745399449832,"tableId":1745418123288,"tableName":"tbl_1081672719","jobId":1745418123323,"jobState":"WAITING_TXN","rollupIndexId":1745418123324,"rollUpIndexName":"mtr_tbl_1081672719_full","baseIndexid":1745418123289,"baseIndexName":"tbl_1081672719"} job=test_cds_upsert_index line=ccr/job.go:3377

```
```
[2025-04-23 22:40:54.463]  INFO txn 7144 ingest binlog: skip the shadow index 1745418123324 job=test_cds_upsert_index line=ccr/ingest_binlog_job.go:570
[2025-04-23 22:40:54.463] DEBUG binlog type: UPSERT, commit seq: 7699, binlog data: {"commitSeq":7699,"txnId":7125,"timeStamp":1745419250589,"label":"label_48330fbaf19e4881_9f27fb92d61e155b","dbId":1745399449832,"tableRecords":{"1745418123288":{"partitionRecords":[{"partitionId":1745418123287,"range":"","version":21,"isTempPartition":false,"stid":-1}],"indexIds":[1745418123289,1745418123324],"deltaRows":{"1745418123290":1}}}} job=test_cds_upsert_index line=ccr/job_pipeline.go:519
[2025-04-23 22:40:54.464]  INFO txn 7144 ingest binlog: run 1 tablet ingest jobs line=ccr/ingest_binlog_job.go:708
[2025-04-23 22:40:54.464] DEBUG handle upsert, table records: [TableRecord{Id: 1745418123288, PartitionRecords: [PartitionRecord{Id: 1745418123287, Range: '', Version: 21, IsTemp: false, Stid: -1}], IndexIds: [1745418123289 1745418123324]}] job=test_cds_upsert_index line=ccr/job_pipeline.go:600
[2025-04-23 22:40:54.464]  INFO begin txn 7145, label: ccrj-7bb3:db_sync:1745399449832:1745399449833:7699, db: 1745399449833 job=test_cds_upsert_index line=ccr/job_pipeline.go:669
[2025-04-23 22:40:54.466]  INFO txn 7145 ingest binlog: skip the shadow index 1745418123324 job=test_cds_upsert_index line=ccr/ingest_binlog_job.go:570
```