### PR TITLE
fix: get new meta before check dropped partition

### DIFF
--- a/pkg/ccr/ingest_binlog_job.go
+++ b/pkg/ccr/ingest_binlog_job.go
@@ -666,7 +666,10 @@ func (j *IngestBinlogJob) prepareTable(tableRecord *record.TableRecord) {
 				partitionRecord.Id, partitionRecord.Range, partitionRecord.Version)
 			continue
 		}
-		if j.srcMeta.IsPartitionDropped(partitionRecord.Id) {
+		if dropped, err := j.ccrJob.IsPartitionDropped(srcTableId, partitionRecord.Id); err != nil {
+			j.setError(err)
+			return
+		} else if dropped {
 			log.Infof("txn %d skip the dropped partition %d, range: %s, version: %d",
 				j.txnId, partitionRecord.Id, partitionRecord.Range, partitionRecord.Version)
 			continue

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -429,6 +429,21 @@ func (j *Job) addExtraInfo(jobInfo []byte) ([]byte, error) {
 	return jobInfoBytes, nil
 }
 
+func (j *Job) IsPartitionDropped(tableId, partitionId int64) (bool, error) {
+	// Keep compatible with the old version, which doesn't have the table id in partial sync data.
+	if tableId == 0 {
+		return false, nil
+	}
+
+	var tableIds = []int64{tableId}
+	srcMeta, err := j.factory.NewThriftMeta(&j.Src, j.factory, tableIds)
+	if err != nil {
+		return false, err
+	}
+
+	return srcMeta.IsPartitionDropped(partitionId), nil
+}
+
 func (j *Job) handlePartialSyncTableNotFound() error {
 	tableId := j.progress.PartialSyncData.TableId
 	table := j.progress.PartialSyncData.Table


### PR DESCRIPTION
The srcMeta not being updated in real time may cause some unwanted fullsync