### PR TITLE
fix: Uninitialized stidMapping causes txn insert not synchronized

### DIFF
--- a/pkg/ccr/ingest_binlog_job.go
+++ b/pkg/ccr/ingest_binlog_job.go
@@ -307,6 +307,7 @@ func NewIngestContext(commitSeq, txnId int64, tableRecords []*record.TableRecord
 		txnId:        txnId,
 		tableRecords: tableRecords,
 		tableMapping: tableMapping,
+		stidMapping:  stidMapping,
 	}
 }
 


### PR DESCRIPTION
`insert into select` is not synchronized

test: test_ts_tbl_txn_insert.groovy