### PR TITLE
fix: after pause is called successfully, status/state should align to job.State that can return "paused" as excepted.

### DIFF
--- a/pkg/ccr/job_manager.go
+++ b/pkg/ccr/job_manager.go
@@ -217,6 +217,8 @@ func (jm *JobManager) GetJobStatus(jobName string) (*JobStatus, error) {
 	defer jm.lock.RUnlock()
 
 	if job, ok := jm.jobs[jobName]; ok {
+		log.Debugf("job rawStatue: %s, job state:%s", job.rawStatus.state, job.State)
+		atomic.StoreInt32(&job.rawStatus.state, int32(job.State))
 		return job.Status(), nil
 	} else {
 		return nil, xerror.Errorf(xerror.Normal, "job not exist: %s", jobName)


### PR DESCRIPTION
fix: after pause is called successfully, status/state should align to job.State that can return "paused" as excepted.