### PR TITLE
feat(ccr): add cluster-level task creation support

### DIFF
--- a/pkg/ccr/base/spec.go
+++ b/pkg/ccr/base/spec.go
@@ -83,6 +83,22 @@ func ParseBackupState(state string) BackupState {
 	}
 }
 
+// isSystemDatabase 判断是否为系统数据库，需要跳过
+func isSystemDatabase(dbName string) bool {
+	systemDatabases := []string{
+		"information_schema",
+		"mysql",
+		"__internal_schema",
+	}
+
+	for _, sysDb := range systemDatabases {
+		if dbName == sysDb {
+			return true
+		}
+	}
+	return false
+}
+
 type RestoreState int
 
 const (
@@ -462,6 +478,40 @@ func (s *Spec) GetAllTables() ([]string, error) {
 	}
 
 	return tables, nil
+}
+
+func (s *Spec) GetAllDatabases() ([]string, error) {
+	log.Tracef("get all databases from cluster")
+
+	db, err := s.Connect()
+	if err != nil {
+		return nil, err
+	}
+
+	sql := "SHOW DATABASES"
+	rows, err := db.Query(sql)
+	if err != nil {
+		return nil, xerror.Wrapf(err, xerror.Normal, "query %s failed", sql)
+	}
+	defer rows.Close()
+
+	var databases []string
+	for rows.Next() {
+		var database string
+		if err := rows.Scan(&database); err != nil {
+			return nil, xerror.Wrapf(err, xerror.Normal, "scan database failed")
+		}
+		// 过滤系统数据库
+		if !isSystemDatabase(database) {
+			databases = append(databases, database)
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, xerror.Wrapf(err, xerror.Normal, "rows error")
+	}
+
+	return databases, nil
 }
 
 func (s *Spec) queryResult(querySQL string, queryColumn string, errMsg string) ([]string, error) {

--- a/pkg/ccr/base/spec.go
+++ b/pkg/ccr/base/spec.go
@@ -83,7 +83,7 @@ func ParseBackupState(state string) BackupState {
 	}
 }
 
-// isSystemDatabase 判断是否为系统数据库，需要跳过
+// isSystemDatabase determines if it's a system database that should be skipped
 func isSystemDatabase(dbName string) bool {
 	systemDatabases := []string{
 		"information_schema",
@@ -501,7 +501,7 @@ func (s *Spec) GetAllDatabases() ([]string, error) {
 		if err := rows.Scan(&database); err != nil {
 			return nil, xerror.Wrapf(err, xerror.Normal, "scan database failed")
 		}
-		// 过滤系统数据库
+		// Filter system databases
 		if !isSystemDatabase(database) {
 			databases = append(databases, database)
 		}
@@ -823,6 +823,45 @@ func (s *Spec) CreateSnapshot(snapshotName string, tables []string) error {
 	return nil
 }
 
+// CreateGlobalSnapshot creates a global snapshot for synchronizing global objects
+// Sets different properties based on different options
+func (s *Spec) CreateGlobalSnapshot(snapshotName string, backupPrivilege, backupCatalog, backupWorkloadGroup bool) error {
+	log.Infof("Creating global snapshot %s", snapshotName)
+
+	db, err := s.Connect()
+	if err != nil {
+		return err
+	}
+
+	// Build SQL statement
+	sql := fmt.Sprintf("BACKUP GLOBAL SNAPSHOT %s TO `__keep_on_local__`", utils.FormatKeywordName(snapshotName))
+
+	// Add properties based on different options
+	properties := make([]string, 0)
+	if backupPrivilege {
+		properties = append(properties, "\"backup_privilege\" = \"true\"")
+	}
+	if backupCatalog {
+		properties = append(properties, "\"backup_catalog\" = \"true\"")
+	}
+	if backupWorkloadGroup {
+		properties = append(properties, "\"backup_workload_group\" = \"true\"")
+	}
+
+	// If there are properties, add PROPERTIES clause
+	if len(properties) > 0 {
+		sql += fmt.Sprintf(" PROPERTIES (%s)", strings.Join(properties, ", "))
+	}
+
+	log.Infof("Creating global snapshot SQL: %s", sql)
+	_, err = db.Exec(sql)
+	if err != nil {
+		return xerror.Wrapf(err, xerror.Normal, "Failed to create global snapshot %s, SQL: %s", snapshotName, sql)
+	}
+
+	return nil
+}
+
 // mysql> BACKUP SNAPSHOT ccr.snapshot_20230605 TO `__keep_on_local__` ON (src_1 PARTITION (`p1`)) PROPERTIES ("type" = "full");
 func (s *Spec) CreatePartialSnapshot(snapshotName, table string, partitions []string) error {
 	if len(table) == 0 {
@@ -895,6 +934,87 @@ func (s *Spec) checkBackupFinished(snapshotName string) (BackupState, string, er
 	}
 
 	return BackupStateUnknown, "", xerror.Errorf(xerror.Normal, "no backup state found, sql: %s", sql)
+}
+
+// checkGlobalBackupFinished checks global backup status
+func (s *Spec) checkGlobalBackupFinished(snapshotName string) (BackupState, string, error) {
+	log.Tracef("Checking global backup status %s", snapshotName)
+
+	db, err := s.Connect()
+	if err != nil {
+		return BackupStateUnknown, "", err
+	}
+
+	sql := fmt.Sprintf("SHOW GLOBAL BACKUP WHERE SnapshotName = \"%s\"", snapshotName)
+	log.Infof("Checking global backup status SQL: %s", sql)
+	rows, err := db.Query(sql)
+	if err != nil {
+		return BackupStateUnknown, "", xerror.Wrapf(err, xerror.Normal, "Failed to query global backup status, SQL: %s", sql)
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		rowParser := utils.NewRowParser()
+		if err := rowParser.Parse(rows); err != nil {
+			return BackupStateUnknown, "", xerror.Wrap(err, xerror.Normal, sql)
+		}
+
+		stateStr, err := rowParser.GetString("State")
+		if err != nil {
+			return BackupStateUnknown, "", xerror.Wrap(err, xerror.Normal, "Failed to parse global backup State")
+		}
+
+		status, err := rowParser.GetString("Status")
+		if err != nil {
+			return BackupStateUnknown, "", xerror.Wrap(err, xerror.Normal, "Failed to parse global backup Status")
+		}
+
+		log.Infof("Checking global snapshot %s backup status: [%v]", snapshotName, stateStr)
+		return ParseBackupState(stateStr), status, nil
+	}
+
+	if err := rows.Err(); err != nil {
+		return BackupStateUnknown, "", xerror.Wrapf(err, xerror.Normal, "Check global backup status, SQL: %s", sql)
+	}
+
+	return BackupStateUnknown, "", xerror.Errorf(xerror.Normal, "Global backup status not found, SQL: %s", sql)
+}
+
+// CheckGlobalBackupFinished checks if global backup is finished
+func (s *Spec) CheckGlobalBackupFinished(snapshotName string) (bool, error) {
+	log.Tracef("Checking if global backup is finished, spec: %s, snapshot: %s", s.String(), snapshotName)
+
+	// Retry network related errors to avoid full sync when target network is interrupted or process is restarted
+	if backupState, status, err := s.checkGlobalBackupFinished(snapshotName); err != nil && !isNetworkRelated(err) {
+		return false, err
+	} else if err == nil && backupState == BackupStateFinished {
+		return true, nil
+	} else if err == nil && backupState == BackupStateCancelled {
+		return false, xerror.Errorf(xerror.Normal, "Global backup failed or cancelled, backup status: %s", status)
+	} else {
+		// BackupStatePending, BackupStateUnknown or network related errors
+		if err != nil {
+			log.Warnf("Failed to check global backup status, spec: %s, snapshot: %s, err: %v", s.String(), snapshotName, err)
+		}
+		return false, nil
+	}
+}
+
+func (s *Spec) RestoreGlobalInfo(sqls string) error {
+	log.Infof("Restoring global information")
+
+	db, err := s.Connect()
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Executing global restore SQL: %s", sqls)
+	_, err = db.Exec(sqls)
+	if err != nil {
+		return xerror.Wrapf(err, xerror.Normal, "Failed to restore global information, SQL: %s", sqls)
+	}
+
+	return nil
 }
 
 func (s *Spec) CheckBackupFinished(snapshotName string) (bool, error) {

--- a/pkg/ccr/base/specer.go
+++ b/pkg/ccr/base/specer.go
@@ -47,7 +47,10 @@ type Specer interface {
 	CancelRestoreIfExists(snapshotName string) error
 	CreatePartialSnapshot(snapshotName, table string, partitions []string) error
 	CreateSnapshot(snapshotName string, tables []string) error
+	CreateGlobalSnapshot(snapshotName string, backupPrivilege, backupCatalog, backupWorkloadGroup bool) error
+	RestoreGlobalInfo(sqls string) error
 	CheckBackupFinished(snapshotName string) (bool, error)
+	CheckGlobalBackupFinished(snapshotName string) (bool, error)
 	CheckRestoreFinished(snapshotName string) (bool, error)
 	GetRestoreSignatureNotMatchedTableOrView(snapshotName string) (string, bool, error)
 	WaitTransactionDone(txnId int64) // busy wait

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -127,8 +127,9 @@ func init() {
 type SyncType int
 
 const (
-	DBSync    SyncType = 0
-	TableSync SyncType = 1
+	DBSync      SyncType = 0
+	TableSync   SyncType = 1
+	ClusterSync SyncType = 2
 )
 
 func (s SyncType) String() string {
@@ -137,6 +138,8 @@ func (s SyncType) String() string {
 		return "db_sync"
 	case TableSync:
 		return "table_sync"
+	case ClusterSync:
+		return "cluster_sync"
 	default:
 		return "unknown_sync"
 	}

--- a/pkg/ccr/specer_mock.go
+++ b/pkg/ccr/specer_mock.go
@@ -217,6 +217,21 @@ func (mr *MockSpecerMockRecorder) Exec(sql any) *gomock.Call {
 }
 
 // GetAllTables mocks base method.
+func (m *MockSpecer) GetAllDatabases() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllDatabases")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllDatabases indicates an expected call of GetAllDatabases.
+func (mr *MockSpecerMockRecorder) GetAllDatabases() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllDatabases", reflect.TypeOf((*MockSpecer)(nil).GetAllDatabases))
+}
+
+// GetAllTables mocks base method.
 func (m *MockSpecer) GetAllTables() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllTables")

--- a/pkg/ccr/utils.go
+++ b/pkg/ccr/utils.go
@@ -55,6 +55,10 @@ func NewBackupJobInfoFromJson(data []byte) (*BackupJobInfo, error) {
 	return jobInfo, nil
 }
 
+func NewBackupSqlsFromBytes(backupSqls []byte) (string, error) {
+	return string(backupSqls), nil
+}
+
 func (i *BackupJobInfo) TableNameMapping() map[int64]string {
 	tableMapping := make(map[int64]string)
 	for tableName, tableInfo := range i.BackupObjects {

--- a/pkg/rpc/fe.go
+++ b/pkg/rpc/fe.go
@@ -108,6 +108,7 @@ type IFeRpc interface {
 	GetBinlog(*base.Spec, int64, int64) (*festruct.TGetBinlogResult_, error)
 	GetBinlogLag(*base.Spec, int64) (*festruct.TGetBinlogLagResult_, error)
 	GetSnapshot(*base.Spec, string, bool) (*festruct.TGetSnapshotResult_, error)
+	GetGlobalSnapshot(*base.Spec, string) (*festruct.TGetGlobalSnapshotResult_, error)
 	RestoreSnapshot(*base.Spec, *RestoreSnapshotRequest) (*festruct.TRestoreSnapshotResult_, error)
 	GetMasterToken(*base.Spec) (*festruct.TGetMasterTokenResult_, error)
 	GetDbMeta(spec *base.Spec) (*festruct.TGetMetaResult_, error)
@@ -471,6 +472,14 @@ func (rpc *FeRpc) GetSnapshot(spec *base.Spec, labelName string, compress bool) 
 	return convertResult[festruct.TGetSnapshotResult_](result, err)
 }
 
+func (rpc *FeRpc) GetGlobalSnapshot(spec *base.Spec, labelName string) (*festruct.TGetGlobalSnapshotResult_, error) {
+	caller := func(client IFeRpc) (resultType, error) {
+		return client.GetGlobalSnapshot(spec, labelName)
+	}
+	result, err := rpc.callWithMasterRedirect(caller)
+	return convertResult[festruct.TGetGlobalSnapshotResult_](result, err)
+}
+
 func (rpc *FeRpc) RestoreSnapshot(spec *base.Spec, req *RestoreSnapshotRequest) (*festruct.TRestoreSnapshotResult_, error) {
 	caller := func(client IFeRpc) (resultType, error) {
 		return client.RestoreSnapshot(spec, req)
@@ -796,6 +805,41 @@ func (rpc *singleFeClient) GetSnapshot(spec *base.Spec, labelName string, compre
 		req.GetUser(), req.GetDb(), req.GetTable(), req.GetLabelName(), req.GetSnapshotName(), req.GetSnapshotType(), req.GetEnableCompress())
 	if resp, err := client.GetSnapshot(context.Background(), req); err != nil {
 		return nil, xerror.Wrapf(err, xerror.RPC, "GetSnapshot error: %v, req: %+v", err, req)
+	} else {
+		return resp, nil
+	}
+}
+
+//	struct TGetGlobalSnapshotRequest {
+//	    1: optional string cluster
+//	    2: optional string user
+//	    3: optional string passwd
+//	    4: optional string token
+//	    5: optional string label_name
+//	    6: optional string snapshot_name
+//	    7: optional TSnapshotType snapshot_type
+//	}
+//
+// Get Global Snapshot rpc
+func (rpc *singleFeClient) GetGlobalSnapshot(spec *base.Spec, labelName string) (*festruct.TGetGlobalSnapshotResult_, error) {
+	log.Tracef("Call GetGlobalSnapshot, addr: %s, spec: %s, label: %s", rpc.Address(), spec, labelName)
+
+	defer xmetrics.RecordFeRpc("GetGlobalSnapshot", rpc.addr)()
+
+	client := rpc.client
+	snapshotType := festruct.TSnapshotType_LOCAL
+	req := &festruct.TGetGlobalSnapshotRequest{
+		Cluster:      &spec.Cluster,
+		User:         &spec.User,
+		Passwd:       &spec.Password,
+		SnapshotName: &labelName,
+		SnapshotType: &snapshotType,
+	}
+
+	log.Tracef("GetGlobalSnapshotRequest user %s, cluster %s, snapshot name %s, snapshot type %d",
+		req.GetUser(), req.GetCluster(), req.GetSnapshotName(), req.GetSnapshotType())
+	if resp, err := client.GetGlobalSnapshot(context.Background(), req); err != nil {
+		return nil, xerror.Wrapf(err, xerror.RPC, "GetGlobalSnapshot error: %v, req: %+v", err, req)
 	} else {
 		return resp, nil
 	}

--- a/pkg/rpc/kitex_gen/frontendservice/FrontendService.go
+++ b/pkg/rpc/kitex_gen/frontendservice/FrontendService.go
@@ -53734,6 +53734,1094 @@ func (p *TGetSnapshotResult_) Field7DeepEqual(src *int64) bool {
 	return true
 }
 
+type TGetGlobalSnapshotRequest struct {
+	Cluster      *string        `thrift:"cluster,1,optional" frugal:"1,optional,string" json:"cluster,omitempty"`
+	User         *string        `thrift:"user,2,optional" frugal:"2,optional,string" json:"user,omitempty"`
+	Passwd       *string        `thrift:"passwd,3,optional" frugal:"3,optional,string" json:"passwd,omitempty"`
+	Token        *string        `thrift:"token,4,optional" frugal:"4,optional,string" json:"token,omitempty"`
+	LabelName    *string        `thrift:"label_name,5,optional" frugal:"5,optional,string" json:"label_name,omitempty"`
+	SnapshotName *string        `thrift:"snapshot_name,6,optional" frugal:"6,optional,string" json:"snapshot_name,omitempty"`
+	SnapshotType *TSnapshotType `thrift:"snapshot_type,7,optional" frugal:"7,optional,TSnapshotType" json:"snapshot_type,omitempty"`
+}
+
+func NewTGetGlobalSnapshotRequest() *TGetGlobalSnapshotRequest {
+	return &TGetGlobalSnapshotRequest{}
+}
+
+func (p *TGetGlobalSnapshotRequest) InitDefault() {
+}
+
+var TGetGlobalSnapshotRequest_Cluster_DEFAULT string
+
+func (p *TGetGlobalSnapshotRequest) GetCluster() (v string) {
+	if !p.IsSetCluster() {
+		return TGetGlobalSnapshotRequest_Cluster_DEFAULT
+	}
+	return *p.Cluster
+}
+
+var TGetGlobalSnapshotRequest_User_DEFAULT string
+
+func (p *TGetGlobalSnapshotRequest) GetUser() (v string) {
+	if !p.IsSetUser() {
+		return TGetGlobalSnapshotRequest_User_DEFAULT
+	}
+	return *p.User
+}
+
+var TGetGlobalSnapshotRequest_Passwd_DEFAULT string
+
+func (p *TGetGlobalSnapshotRequest) GetPasswd() (v string) {
+	if !p.IsSetPasswd() {
+		return TGetGlobalSnapshotRequest_Passwd_DEFAULT
+	}
+	return *p.Passwd
+}
+
+var TGetGlobalSnapshotRequest_Token_DEFAULT string
+
+func (p *TGetGlobalSnapshotRequest) GetToken() (v string) {
+	if !p.IsSetToken() {
+		return TGetGlobalSnapshotRequest_Token_DEFAULT
+	}
+	return *p.Token
+}
+
+var TGetGlobalSnapshotRequest_LabelName_DEFAULT string
+
+func (p *TGetGlobalSnapshotRequest) GetLabelName() (v string) {
+	if !p.IsSetLabelName() {
+		return TGetGlobalSnapshotRequest_LabelName_DEFAULT
+	}
+	return *p.LabelName
+}
+
+var TGetGlobalSnapshotRequest_SnapshotName_DEFAULT string
+
+func (p *TGetGlobalSnapshotRequest) GetSnapshotName() (v string) {
+	if !p.IsSetSnapshotName() {
+		return TGetGlobalSnapshotRequest_SnapshotName_DEFAULT
+	}
+	return *p.SnapshotName
+}
+
+var TGetGlobalSnapshotRequest_SnapshotType_DEFAULT TSnapshotType
+
+func (p *TGetGlobalSnapshotRequest) GetSnapshotType() (v TSnapshotType) {
+	if !p.IsSetSnapshotType() {
+		return TGetGlobalSnapshotRequest_SnapshotType_DEFAULT
+	}
+	return *p.SnapshotType
+}
+func (p *TGetGlobalSnapshotRequest) SetCluster(val *string) {
+	p.Cluster = val
+}
+func (p *TGetGlobalSnapshotRequest) SetUser(val *string) {
+	p.User = val
+}
+func (p *TGetGlobalSnapshotRequest) SetPasswd(val *string) {
+	p.Passwd = val
+}
+func (p *TGetGlobalSnapshotRequest) SetToken(val *string) {
+	p.Token = val
+}
+func (p *TGetGlobalSnapshotRequest) SetLabelName(val *string) {
+	p.LabelName = val
+}
+func (p *TGetGlobalSnapshotRequest) SetSnapshotName(val *string) {
+	p.SnapshotName = val
+}
+func (p *TGetGlobalSnapshotRequest) SetSnapshotType(val *TSnapshotType) {
+	p.SnapshotType = val
+}
+
+var fieldIDToName_TGetGlobalSnapshotRequest = map[int16]string{
+	1: "cluster",
+	2: "user",
+	3: "passwd",
+	4: "token",
+	5: "label_name",
+	6: "snapshot_name",
+	7: "snapshot_type",
+}
+
+func (p *TGetGlobalSnapshotRequest) IsSetCluster() bool {
+	return p.Cluster != nil
+}
+
+func (p *TGetGlobalSnapshotRequest) IsSetUser() bool {
+	return p.User != nil
+}
+
+func (p *TGetGlobalSnapshotRequest) IsSetPasswd() bool {
+	return p.Passwd != nil
+}
+
+func (p *TGetGlobalSnapshotRequest) IsSetToken() bool {
+	return p.Token != nil
+}
+
+func (p *TGetGlobalSnapshotRequest) IsSetLabelName() bool {
+	return p.LabelName != nil
+}
+
+func (p *TGetGlobalSnapshotRequest) IsSetSnapshotName() bool {
+	return p.SnapshotName != nil
+}
+
+func (p *TGetGlobalSnapshotRequest) IsSetSnapshotType() bool {
+	return p.SnapshotType != nil
+}
+
+func (p *TGetGlobalSnapshotRequest) Read(iprot thrift.TProtocol) (err error) {
+
+	var fieldTypeId thrift.TType
+	var fieldId int16
+
+	if _, err = iprot.ReadStructBegin(); err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err = iprot.ReadFieldBegin()
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField1(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 2:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField2(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 3:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField3(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 4:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField4(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 5:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField5(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 6:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField6(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 7:
+			if fieldTypeId == thrift.I32 {
+				if err = p.ReadField7(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		default:
+			if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		}
+		if err = iprot.ReadFieldEnd(); err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	if err = iprot.ReadStructEnd(); err != nil {
+		goto ReadStructEndError
+	}
+
+	return nil
+ReadStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_TGetGlobalSnapshotRequest[fieldId]), err)
+SkipFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+
+ReadFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotRequest) ReadField1(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Cluster = _field
+	return nil
+}
+func (p *TGetGlobalSnapshotRequest) ReadField2(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.User = _field
+	return nil
+}
+func (p *TGetGlobalSnapshotRequest) ReadField3(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Passwd = _field
+	return nil
+}
+func (p *TGetGlobalSnapshotRequest) ReadField4(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Token = _field
+	return nil
+}
+func (p *TGetGlobalSnapshotRequest) ReadField5(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.LabelName = _field
+	return nil
+}
+func (p *TGetGlobalSnapshotRequest) ReadField6(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.SnapshotName = _field
+	return nil
+}
+func (p *TGetGlobalSnapshotRequest) ReadField7(iprot thrift.TProtocol) error {
+
+	var _field *TSnapshotType
+	if v, err := iprot.ReadI32(); err != nil {
+		return err
+	} else {
+		tmp := TSnapshotType(v)
+		_field = &tmp
+	}
+	p.SnapshotType = _field
+	return nil
+}
+
+func (p *TGetGlobalSnapshotRequest) Write(oprot thrift.TProtocol) (err error) {
+	var fieldId int16
+	if err = oprot.WriteStructBegin("TGetGlobalSnapshotRequest"); err != nil {
+		goto WriteStructBeginError
+	}
+	if p != nil {
+		if err = p.writeField1(oprot); err != nil {
+			fieldId = 1
+			goto WriteFieldError
+		}
+		if err = p.writeField2(oprot); err != nil {
+			fieldId = 2
+			goto WriteFieldError
+		}
+		if err = p.writeField3(oprot); err != nil {
+			fieldId = 3
+			goto WriteFieldError
+		}
+		if err = p.writeField4(oprot); err != nil {
+			fieldId = 4
+			goto WriteFieldError
+		}
+		if err = p.writeField5(oprot); err != nil {
+			fieldId = 5
+			goto WriteFieldError
+		}
+		if err = p.writeField6(oprot); err != nil {
+			fieldId = 6
+			goto WriteFieldError
+		}
+		if err = p.writeField7(oprot); err != nil {
+			fieldId = 7
+			goto WriteFieldError
+		}
+	}
+	if err = oprot.WriteFieldStop(); err != nil {
+		goto WriteFieldStopError
+	}
+	if err = oprot.WriteStructEnd(); err != nil {
+		goto WriteStructEndError
+	}
+	return nil
+WriteStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+WriteFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T write field %d error: ", p, fieldId), err)
+WriteFieldStopError:
+	return thrift.PrependError(fmt.Sprintf("%T write field stop error: ", p), err)
+WriteStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotRequest) writeField1(oprot thrift.TProtocol) (err error) {
+	if p.IsSetCluster() {
+		if err = oprot.WriteFieldBegin("cluster", thrift.STRING, 1); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.Cluster); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotRequest) writeField2(oprot thrift.TProtocol) (err error) {
+	if p.IsSetUser() {
+		if err = oprot.WriteFieldBegin("user", thrift.STRING, 2); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.User); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotRequest) writeField3(oprot thrift.TProtocol) (err error) {
+	if p.IsSetPasswd() {
+		if err = oprot.WriteFieldBegin("passwd", thrift.STRING, 3); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.Passwd); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotRequest) writeField4(oprot thrift.TProtocol) (err error) {
+	if p.IsSetToken() {
+		if err = oprot.WriteFieldBegin("token", thrift.STRING, 4); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.Token); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 4 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 4 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotRequest) writeField5(oprot thrift.TProtocol) (err error) {
+	if p.IsSetLabelName() {
+		if err = oprot.WriteFieldBegin("label_name", thrift.STRING, 5); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.LabelName); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 5 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 5 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotRequest) writeField6(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSnapshotName() {
+		if err = oprot.WriteFieldBegin("snapshot_name", thrift.STRING, 6); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.SnapshotName); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 6 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 6 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotRequest) writeField7(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSnapshotType() {
+		if err = oprot.WriteFieldBegin("snapshot_type", thrift.I32, 7); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI32(int32(*p.SnapshotType)); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 7 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 7 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotRequest) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("TGetGlobalSnapshotRequest(%+v)", *p)
+
+}
+
+func (p *TGetGlobalSnapshotRequest) DeepEqual(ano *TGetGlobalSnapshotRequest) bool {
+	if p == ano {
+		return true
+	} else if p == nil || ano == nil {
+		return false
+	}
+	if !p.Field1DeepEqual(ano.Cluster) {
+		return false
+	}
+	if !p.Field2DeepEqual(ano.User) {
+		return false
+	}
+	if !p.Field3DeepEqual(ano.Passwd) {
+		return false
+	}
+	if !p.Field4DeepEqual(ano.Token) {
+		return false
+	}
+	if !p.Field5DeepEqual(ano.LabelName) {
+		return false
+	}
+	if !p.Field6DeepEqual(ano.SnapshotName) {
+		return false
+	}
+	if !p.Field7DeepEqual(ano.SnapshotType) {
+		return false
+	}
+	return true
+}
+
+func (p *TGetGlobalSnapshotRequest) Field1DeepEqual(src *string) bool {
+
+	if p.Cluster == src {
+		return true
+	} else if p.Cluster == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.Cluster, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TGetGlobalSnapshotRequest) Field2DeepEqual(src *string) bool {
+
+	if p.User == src {
+		return true
+	} else if p.User == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.User, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TGetGlobalSnapshotRequest) Field3DeepEqual(src *string) bool {
+
+	if p.Passwd == src {
+		return true
+	} else if p.Passwd == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.Passwd, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TGetGlobalSnapshotRequest) Field4DeepEqual(src *string) bool {
+
+	if p.Token == src {
+		return true
+	} else if p.Token == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.Token, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TGetGlobalSnapshotRequest) Field5DeepEqual(src *string) bool {
+
+	if p.LabelName == src {
+		return true
+	} else if p.LabelName == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.LabelName, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TGetGlobalSnapshotRequest) Field6DeepEqual(src *string) bool {
+
+	if p.SnapshotName == src {
+		return true
+	} else if p.SnapshotName == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.SnapshotName, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TGetGlobalSnapshotRequest) Field7DeepEqual(src *TSnapshotType) bool {
+
+	if p.SnapshotType == src {
+		return true
+	} else if p.SnapshotType == nil || src == nil {
+		return false
+	}
+	if *p.SnapshotType != *src {
+		return false
+	}
+	return true
+}
+
+type TGetGlobalSnapshotResult_ struct {
+	Status        *status.TStatus        `thrift:"status,1,optional" frugal:"1,optional,status.TStatus" json:"status,omitempty"`
+	GlobalInfo    []byte                 `thrift:"global_info,2,optional" frugal:"2,optional,binary" json:"global_info,omitempty"`
+	MasterAddress *types.TNetworkAddress `thrift:"master_address,3,optional" frugal:"3,optional,types.TNetworkAddress" json:"master_address,omitempty"`
+	ExpiredAt     *int64                 `thrift:"expiredAt,4,optional" frugal:"4,optional,i64" json:"expiredAt,omitempty"`
+	CommitSeq     *int64                 `thrift:"commit_seq,5,optional" frugal:"5,optional,i64" json:"commit_seq,omitempty"`
+}
+
+func NewTGetGlobalSnapshotResult_() *TGetGlobalSnapshotResult_ {
+	return &TGetGlobalSnapshotResult_{}
+}
+
+func (p *TGetGlobalSnapshotResult_) InitDefault() {
+}
+
+var TGetGlobalSnapshotResult__Status_DEFAULT *status.TStatus
+
+func (p *TGetGlobalSnapshotResult_) GetStatus() (v *status.TStatus) {
+	if !p.IsSetStatus() {
+		return TGetGlobalSnapshotResult__Status_DEFAULT
+	}
+	return p.Status
+}
+
+var TGetGlobalSnapshotResult__GlobalInfo_DEFAULT []byte
+
+func (p *TGetGlobalSnapshotResult_) GetGlobalInfo() (v []byte) {
+	if !p.IsSetGlobalInfo() {
+		return TGetGlobalSnapshotResult__GlobalInfo_DEFAULT
+	}
+	return p.GlobalInfo
+}
+
+var TGetGlobalSnapshotResult__MasterAddress_DEFAULT *types.TNetworkAddress
+
+func (p *TGetGlobalSnapshotResult_) GetMasterAddress() (v *types.TNetworkAddress) {
+	if !p.IsSetMasterAddress() {
+		return TGetGlobalSnapshotResult__MasterAddress_DEFAULT
+	}
+	return p.MasterAddress
+}
+
+var TGetGlobalSnapshotResult__ExpiredAt_DEFAULT int64
+
+func (p *TGetGlobalSnapshotResult_) GetExpiredAt() (v int64) {
+	if !p.IsSetExpiredAt() {
+		return TGetGlobalSnapshotResult__ExpiredAt_DEFAULT
+	}
+	return *p.ExpiredAt
+}
+
+var TGetGlobalSnapshotResult__CommitSeq_DEFAULT int64
+
+func (p *TGetGlobalSnapshotResult_) GetCommitSeq() (v int64) {
+	if !p.IsSetCommitSeq() {
+		return TGetGlobalSnapshotResult__CommitSeq_DEFAULT
+	}
+	return *p.CommitSeq
+}
+func (p *TGetGlobalSnapshotResult_) SetStatus(val *status.TStatus) {
+	p.Status = val
+}
+func (p *TGetGlobalSnapshotResult_) SetGlobalInfo(val []byte) {
+	p.GlobalInfo = val
+}
+func (p *TGetGlobalSnapshotResult_) SetMasterAddress(val *types.TNetworkAddress) {
+	p.MasterAddress = val
+}
+func (p *TGetGlobalSnapshotResult_) SetExpiredAt(val *int64) {
+	p.ExpiredAt = val
+}
+func (p *TGetGlobalSnapshotResult_) SetCommitSeq(val *int64) {
+	p.CommitSeq = val
+}
+
+var fieldIDToName_TGetGlobalSnapshotResult_ = map[int16]string{
+	1: "status",
+	2: "global_info",
+	3: "master_address",
+	4: "expiredAt",
+	5: "commit_seq",
+}
+
+func (p *TGetGlobalSnapshotResult_) IsSetStatus() bool {
+	return p.Status != nil
+}
+
+func (p *TGetGlobalSnapshotResult_) IsSetGlobalInfo() bool {
+	return p.GlobalInfo != nil
+}
+
+func (p *TGetGlobalSnapshotResult_) IsSetMasterAddress() bool {
+	return p.MasterAddress != nil
+}
+
+func (p *TGetGlobalSnapshotResult_) IsSetExpiredAt() bool {
+	return p.ExpiredAt != nil
+}
+
+func (p *TGetGlobalSnapshotResult_) IsSetCommitSeq() bool {
+	return p.CommitSeq != nil
+}
+
+func (p *TGetGlobalSnapshotResult_) Read(iprot thrift.TProtocol) (err error) {
+
+	var fieldTypeId thrift.TType
+	var fieldId int16
+
+	if _, err = iprot.ReadStructBegin(); err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err = iprot.ReadFieldBegin()
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				if err = p.ReadField1(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 2:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField2(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 3:
+			if fieldTypeId == thrift.STRUCT {
+				if err = p.ReadField3(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 4:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField4(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 5:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField5(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		default:
+			if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		}
+		if err = iprot.ReadFieldEnd(); err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	if err = iprot.ReadStructEnd(); err != nil {
+		goto ReadStructEndError
+	}
+
+	return nil
+ReadStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_TGetGlobalSnapshotResult_[fieldId]), err)
+SkipFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+
+ReadFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotResult_) ReadField1(iprot thrift.TProtocol) error {
+	_field := status.NewTStatus()
+	if err := _field.Read(iprot); err != nil {
+		return err
+	}
+	p.Status = _field
+	return nil
+}
+func (p *TGetGlobalSnapshotResult_) ReadField2(iprot thrift.TProtocol) error {
+
+	var _field []byte
+	if v, err := iprot.ReadBinary(); err != nil {
+		return err
+	} else {
+		_field = []byte(v)
+	}
+	p.GlobalInfo = _field
+	return nil
+}
+func (p *TGetGlobalSnapshotResult_) ReadField3(iprot thrift.TProtocol) error {
+	_field := types.NewTNetworkAddress()
+	if err := _field.Read(iprot); err != nil {
+		return err
+	}
+	p.MasterAddress = _field
+	return nil
+}
+func (p *TGetGlobalSnapshotResult_) ReadField4(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.ExpiredAt = _field
+	return nil
+}
+func (p *TGetGlobalSnapshotResult_) ReadField5(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.CommitSeq = _field
+	return nil
+}
+
+func (p *TGetGlobalSnapshotResult_) Write(oprot thrift.TProtocol) (err error) {
+	var fieldId int16
+	if err = oprot.WriteStructBegin("TGetGlobalSnapshotResult"); err != nil {
+		goto WriteStructBeginError
+	}
+	if p != nil {
+		if err = p.writeField1(oprot); err != nil {
+			fieldId = 1
+			goto WriteFieldError
+		}
+		if err = p.writeField2(oprot); err != nil {
+			fieldId = 2
+			goto WriteFieldError
+		}
+		if err = p.writeField3(oprot); err != nil {
+			fieldId = 3
+			goto WriteFieldError
+		}
+		if err = p.writeField4(oprot); err != nil {
+			fieldId = 4
+			goto WriteFieldError
+		}
+		if err = p.writeField5(oprot); err != nil {
+			fieldId = 5
+			goto WriteFieldError
+		}
+	}
+	if err = oprot.WriteFieldStop(); err != nil {
+		goto WriteFieldStopError
+	}
+	if err = oprot.WriteStructEnd(); err != nil {
+		goto WriteStructEndError
+	}
+	return nil
+WriteStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+WriteFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T write field %d error: ", p, fieldId), err)
+WriteFieldStopError:
+	return thrift.PrependError(fmt.Sprintf("%T write field stop error: ", p), err)
+WriteStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotResult_) writeField1(oprot thrift.TProtocol) (err error) {
+	if p.IsSetStatus() {
+		if err = oprot.WriteFieldBegin("status", thrift.STRUCT, 1); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := p.Status.Write(oprot); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotResult_) writeField2(oprot thrift.TProtocol) (err error) {
+	if p.IsSetGlobalInfo() {
+		if err = oprot.WriteFieldBegin("global_info", thrift.STRING, 2); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteBinary([]byte(p.GlobalInfo)); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotResult_) writeField3(oprot thrift.TProtocol) (err error) {
+	if p.IsSetMasterAddress() {
+		if err = oprot.WriteFieldBegin("master_address", thrift.STRUCT, 3); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := p.MasterAddress.Write(oprot); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotResult_) writeField4(oprot thrift.TProtocol) (err error) {
+	if p.IsSetExpiredAt() {
+		if err = oprot.WriteFieldBegin("expiredAt", thrift.I64, 4); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.ExpiredAt); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 4 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 4 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotResult_) writeField5(oprot thrift.TProtocol) (err error) {
+	if p.IsSetCommitSeq() {
+		if err = oprot.WriteFieldBegin("commit_seq", thrift.I64, 5); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.CommitSeq); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 5 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 5 end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotResult_) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("TGetGlobalSnapshotResult_(%+v)", *p)
+
+}
+
+func (p *TGetGlobalSnapshotResult_) DeepEqual(ano *TGetGlobalSnapshotResult_) bool {
+	if p == ano {
+		return true
+	} else if p == nil || ano == nil {
+		return false
+	}
+	if !p.Field1DeepEqual(ano.Status) {
+		return false
+	}
+	if !p.Field2DeepEqual(ano.GlobalInfo) {
+		return false
+	}
+	if !p.Field3DeepEqual(ano.MasterAddress) {
+		return false
+	}
+	if !p.Field4DeepEqual(ano.ExpiredAt) {
+		return false
+	}
+	if !p.Field5DeepEqual(ano.CommitSeq) {
+		return false
+	}
+	return true
+}
+
+func (p *TGetGlobalSnapshotResult_) Field1DeepEqual(src *status.TStatus) bool {
+
+	if !p.Status.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+func (p *TGetGlobalSnapshotResult_) Field2DeepEqual(src []byte) bool {
+
+	if bytes.Compare(p.GlobalInfo, src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *TGetGlobalSnapshotResult_) Field3DeepEqual(src *types.TNetworkAddress) bool {
+
+	if !p.MasterAddress.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+func (p *TGetGlobalSnapshotResult_) Field4DeepEqual(src *int64) bool {
+
+	if p.ExpiredAt == src {
+		return true
+	} else if p.ExpiredAt == nil || src == nil {
+		return false
+	}
+	if *p.ExpiredAt != *src {
+		return false
+	}
+	return true
+}
+func (p *TGetGlobalSnapshotResult_) Field5DeepEqual(src *int64) bool {
+
+	if p.CommitSeq == src {
+		return true
+	} else if p.CommitSeq == nil || src == nil {
+		return false
+	}
+	if *p.CommitSeq != *src {
+		return false
+	}
+	return true
+}
+
 type TTableRef struct {
 	Table     *string `thrift:"table,1,optional" frugal:"1,optional,string" json:"table,omitempty"`
 	AliasName *string `thrift:"alias_name,3,optional" frugal:"3,optional,string" json:"alias_name,omitempty"`
@@ -74380,6 +75468,8 @@ type FrontendService interface {
 
 	GetSnapshot(ctx context.Context, request *TGetSnapshotRequest) (r *TGetSnapshotResult_, err error)
 
+	GetGlobalSnapshot(ctx context.Context, request *TGetGlobalSnapshotRequest) (r *TGetGlobalSnapshotResult_, err error)
+
 	RestoreSnapshot(ctx context.Context, request *TRestoreSnapshotRequest) (r *TRestoreSnapshotResult_, err error)
 
 	LockBinlog(ctx context.Context, request *TLockBinlogRequest) (r *TLockBinlogResult_, err error)
@@ -74701,6 +75791,15 @@ func (p *FrontendServiceClient) GetSnapshot(ctx context.Context, request *TGetSn
 	_args.Request = request
 	var _result FrontendServiceGetSnapshotResult
 	if err = p.Client_().Call(ctx, "getSnapshot", &_args, &_result); err != nil {
+		return
+	}
+	return _result.GetSuccess(), nil
+}
+func (p *FrontendServiceClient) GetGlobalSnapshot(ctx context.Context, request *TGetGlobalSnapshotRequest) (r *TGetGlobalSnapshotResult_, err error) {
+	var _args FrontendServiceGetGlobalSnapshotArgs
+	_args.Request = request
+	var _result FrontendServiceGetGlobalSnapshotResult
+	if err = p.Client_().Call(ctx, "getGlobalSnapshot", &_args, &_result); err != nil {
 		return
 	}
 	return _result.GetSuccess(), nil
@@ -75083,6 +76182,7 @@ func NewFrontendServiceProcessor(handler FrontendService) *FrontendServiceProces
 	self.AddToProcessorMap("rollbackTxn", &frontendServiceProcessorRollbackTxn{handler: handler})
 	self.AddToProcessorMap("getBinlog", &frontendServiceProcessorGetBinlog{handler: handler})
 	self.AddToProcessorMap("getSnapshot", &frontendServiceProcessorGetSnapshot{handler: handler})
+	self.AddToProcessorMap("getGlobalSnapshot", &frontendServiceProcessorGetGlobalSnapshot{handler: handler})
 	self.AddToProcessorMap("restoreSnapshot", &frontendServiceProcessorRestoreSnapshot{handler: handler})
 	self.AddToProcessorMap("lockBinlog", &frontendServiceProcessorLockBinlog{handler: handler})
 	self.AddToProcessorMap("waitingTxnStatus", &frontendServiceProcessorWaitingTxnStatus{handler: handler})
@@ -76323,6 +77423,54 @@ func (p *frontendServiceProcessorGetSnapshot) Process(ctx context.Context, seqId
 		result.Success = retval
 	}
 	if err2 = oprot.WriteMessageBegin("getSnapshot", thrift.REPLY, seqId); err2 != nil {
+		err = err2
+	}
+	if err2 = result.Write(oprot); err == nil && err2 != nil {
+		err = err2
+	}
+	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
+		err = err2
+	}
+	if err2 = oprot.Flush(ctx); err == nil && err2 != nil {
+		err = err2
+	}
+	if err != nil {
+		return
+	}
+	return true, err
+}
+
+type frontendServiceProcessorGetGlobalSnapshot struct {
+	handler FrontendService
+}
+
+func (p *frontendServiceProcessorGetGlobalSnapshot) Process(ctx context.Context, seqId int32, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
+	args := FrontendServiceGetGlobalSnapshotArgs{}
+	if err = args.Read(iprot); err != nil {
+		iprot.ReadMessageEnd()
+		x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err.Error())
+		oprot.WriteMessageBegin("getGlobalSnapshot", thrift.EXCEPTION, seqId)
+		x.Write(oprot)
+		oprot.WriteMessageEnd()
+		oprot.Flush(ctx)
+		return false, err
+	}
+
+	iprot.ReadMessageEnd()
+	var err2 error
+	result := FrontendServiceGetGlobalSnapshotResult{}
+	var retval *TGetGlobalSnapshotResult_
+	if retval, err2 = p.handler.GetGlobalSnapshot(ctx, args.Request); err2 != nil {
+		x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing getGlobalSnapshot: "+err2.Error())
+		oprot.WriteMessageBegin("getGlobalSnapshot", thrift.EXCEPTION, seqId)
+		x.Write(oprot)
+		oprot.WriteMessageEnd()
+		oprot.Flush(ctx)
+		return true, err2
+	} else {
+		result.Success = retval
+	}
+	if err2 = oprot.WriteMessageBegin("getGlobalSnapshot", thrift.REPLY, seqId); err2 != nil {
 		err = err2
 	}
 	if err2 = result.Write(oprot); err == nil && err2 != nil {
@@ -86532,6 +87680,346 @@ func (p *FrontendServiceGetSnapshotResult) DeepEqual(ano *FrontendServiceGetSnap
 }
 
 func (p *FrontendServiceGetSnapshotResult) Field0DeepEqual(src *TGetSnapshotResult_) bool {
+
+	if !p.Success.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+
+type FrontendServiceGetGlobalSnapshotArgs struct {
+	Request *TGetGlobalSnapshotRequest `thrift:"request,1" frugal:"1,default,TGetGlobalSnapshotRequest" json:"request"`
+}
+
+func NewFrontendServiceGetGlobalSnapshotArgs() *FrontendServiceGetGlobalSnapshotArgs {
+	return &FrontendServiceGetGlobalSnapshotArgs{}
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) InitDefault() {
+}
+
+var FrontendServiceGetGlobalSnapshotArgs_Request_DEFAULT *TGetGlobalSnapshotRequest
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) GetRequest() (v *TGetGlobalSnapshotRequest) {
+	if !p.IsSetRequest() {
+		return FrontendServiceGetGlobalSnapshotArgs_Request_DEFAULT
+	}
+	return p.Request
+}
+func (p *FrontendServiceGetGlobalSnapshotArgs) SetRequest(val *TGetGlobalSnapshotRequest) {
+	p.Request = val
+}
+
+var fieldIDToName_FrontendServiceGetGlobalSnapshotArgs = map[int16]string{
+	1: "request",
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) IsSetRequest() bool {
+	return p.Request != nil
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) Read(iprot thrift.TProtocol) (err error) {
+
+	var fieldTypeId thrift.TType
+	var fieldId int16
+
+	if _, err = iprot.ReadStructBegin(); err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err = iprot.ReadFieldBegin()
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				if err = p.ReadField1(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		default:
+			if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		}
+		if err = iprot.ReadFieldEnd(); err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	if err = iprot.ReadStructEnd(); err != nil {
+		goto ReadStructEndError
+	}
+
+	return nil
+ReadStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_FrontendServiceGetGlobalSnapshotArgs[fieldId]), err)
+SkipFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+
+ReadFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) ReadField1(iprot thrift.TProtocol) error {
+	_field := NewTGetGlobalSnapshotRequest()
+	if err := _field.Read(iprot); err != nil {
+		return err
+	}
+	p.Request = _field
+	return nil
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) Write(oprot thrift.TProtocol) (err error) {
+	var fieldId int16
+	if err = oprot.WriteStructBegin("getGlobalSnapshot_args"); err != nil {
+		goto WriteStructBeginError
+	}
+	if p != nil {
+		if err = p.writeField1(oprot); err != nil {
+			fieldId = 1
+			goto WriteFieldError
+		}
+	}
+	if err = oprot.WriteFieldStop(); err != nil {
+		goto WriteFieldStopError
+	}
+	if err = oprot.WriteStructEnd(); err != nil {
+		goto WriteStructEndError
+	}
+	return nil
+WriteStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+WriteFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T write field %d error: ", p, fieldId), err)
+WriteFieldStopError:
+	return thrift.PrependError(fmt.Sprintf("%T write field stop error: ", p), err)
+WriteStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct end error: ", p), err)
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) writeField1(oprot thrift.TProtocol) (err error) {
+	if err = oprot.WriteFieldBegin("request", thrift.STRUCT, 1); err != nil {
+		goto WriteFieldBeginError
+	}
+	if err := p.Request.Write(oprot); err != nil {
+		return err
+	}
+	if err = oprot.WriteFieldEnd(); err != nil {
+		goto WriteFieldEndError
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 end error: ", p), err)
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("FrontendServiceGetGlobalSnapshotArgs(%+v)", *p)
+
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) DeepEqual(ano *FrontendServiceGetGlobalSnapshotArgs) bool {
+	if p == ano {
+		return true
+	} else if p == nil || ano == nil {
+		return false
+	}
+	if !p.Field1DeepEqual(ano.Request) {
+		return false
+	}
+	return true
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) Field1DeepEqual(src *TGetGlobalSnapshotRequest) bool {
+
+	if !p.Request.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+
+type FrontendServiceGetGlobalSnapshotResult struct {
+	Success *TGetGlobalSnapshotResult_ `thrift:"success,0,optional" frugal:"0,optional,TGetGlobalSnapshotResult_" json:"success,omitempty"`
+}
+
+func NewFrontendServiceGetGlobalSnapshotResult() *FrontendServiceGetGlobalSnapshotResult {
+	return &FrontendServiceGetGlobalSnapshotResult{}
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) InitDefault() {
+}
+
+var FrontendServiceGetGlobalSnapshotResult_Success_DEFAULT *TGetGlobalSnapshotResult_
+
+func (p *FrontendServiceGetGlobalSnapshotResult) GetSuccess() (v *TGetGlobalSnapshotResult_) {
+	if !p.IsSetSuccess() {
+		return FrontendServiceGetGlobalSnapshotResult_Success_DEFAULT
+	}
+	return p.Success
+}
+func (p *FrontendServiceGetGlobalSnapshotResult) SetSuccess(x interface{}) {
+	p.Success = x.(*TGetGlobalSnapshotResult_)
+}
+
+var fieldIDToName_FrontendServiceGetGlobalSnapshotResult = map[int16]string{
+	0: "success",
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) IsSetSuccess() bool {
+	return p.Success != nil
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) Read(iprot thrift.TProtocol) (err error) {
+
+	var fieldTypeId thrift.TType
+	var fieldId int16
+
+	if _, err = iprot.ReadStructBegin(); err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err = iprot.ReadFieldBegin()
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+
+		switch fieldId {
+		case 0:
+			if fieldTypeId == thrift.STRUCT {
+				if err = p.ReadField0(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		default:
+			if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		}
+		if err = iprot.ReadFieldEnd(); err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	if err = iprot.ReadStructEnd(); err != nil {
+		goto ReadStructEndError
+	}
+
+	return nil
+ReadStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_FrontendServiceGetGlobalSnapshotResult[fieldId]), err)
+SkipFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+
+ReadFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) ReadField0(iprot thrift.TProtocol) error {
+	_field := NewTGetGlobalSnapshotResult_()
+	if err := _field.Read(iprot); err != nil {
+		return err
+	}
+	p.Success = _field
+	return nil
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) Write(oprot thrift.TProtocol) (err error) {
+	var fieldId int16
+	if err = oprot.WriteStructBegin("getGlobalSnapshot_result"); err != nil {
+		goto WriteStructBeginError
+	}
+	if p != nil {
+		if err = p.writeField0(oprot); err != nil {
+			fieldId = 0
+			goto WriteFieldError
+		}
+	}
+	if err = oprot.WriteFieldStop(); err != nil {
+		goto WriteFieldStopError
+	}
+	if err = oprot.WriteStructEnd(); err != nil {
+		goto WriteStructEndError
+	}
+	return nil
+WriteStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+WriteFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T write field %d error: ", p, fieldId), err)
+WriteFieldStopError:
+	return thrift.PrependError(fmt.Sprintf("%T write field stop error: ", p), err)
+WriteStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct end error: ", p), err)
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) writeField0(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSuccess() {
+		if err = oprot.WriteFieldBegin("success", thrift.STRUCT, 0); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := p.Success.Write(oprot); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 0 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 0 end error: ", p), err)
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("FrontendServiceGetGlobalSnapshotResult(%+v)", *p)
+
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) DeepEqual(ano *FrontendServiceGetGlobalSnapshotResult) bool {
+	if p == ano {
+		return true
+	} else if p == nil || ano == nil {
+		return false
+	}
+	if !p.Field0DeepEqual(ano.Success) {
+		return false
+	}
+	return true
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) Field0DeepEqual(src *TGetGlobalSnapshotResult_) bool {
 
 	if !p.Success.DeepEqual(src) {
 		return false

--- a/pkg/rpc/kitex_gen/frontendservice/frontendservice/client.go
+++ b/pkg/rpc/kitex_gen/frontendservice/frontendservice/client.go
@@ -38,6 +38,7 @@ type Client interface {
 	RollbackTxn(ctx context.Context, request *frontendservice.TRollbackTxnRequest, callOptions ...callopt.Option) (r *frontendservice.TRollbackTxnResult_, err error)
 	GetBinlog(ctx context.Context, request *frontendservice.TGetBinlogRequest, callOptions ...callopt.Option) (r *frontendservice.TGetBinlogResult_, err error)
 	GetSnapshot(ctx context.Context, request *frontendservice.TGetSnapshotRequest, callOptions ...callopt.Option) (r *frontendservice.TGetSnapshotResult_, err error)
+	GetGlobalSnapshot(ctx context.Context, request *frontendservice.TGetGlobalSnapshotRequest, callOptions ...callopt.Option) (r *frontendservice.TGetGlobalSnapshotResult_, err error)
 	RestoreSnapshot(ctx context.Context, request *frontendservice.TRestoreSnapshotRequest, callOptions ...callopt.Option) (r *frontendservice.TRestoreSnapshotResult_, err error)
 	LockBinlog(ctx context.Context, request *frontendservice.TLockBinlogRequest, callOptions ...callopt.Option) (r *frontendservice.TLockBinlogResult_, err error)
 	WaitingTxnStatus(ctx context.Context, request *frontendservice.TWaitingTxnStatusRequest, callOptions ...callopt.Option) (r *frontendservice.TWaitingTxnStatusResult_, err error)
@@ -229,6 +230,11 @@ func (p *kFrontendServiceClient) GetBinlog(ctx context.Context, request *fronten
 func (p *kFrontendServiceClient) GetSnapshot(ctx context.Context, request *frontendservice.TGetSnapshotRequest, callOptions ...callopt.Option) (r *frontendservice.TGetSnapshotResult_, err error) {
 	ctx = client.NewCtxWithCallOptions(ctx, callOptions)
 	return p.kClient.GetSnapshot(ctx, request)
+}
+
+func (p *kFrontendServiceClient) GetGlobalSnapshot(ctx context.Context, request *frontendservice.TGetGlobalSnapshotRequest, callOptions ...callopt.Option) (r *frontendservice.TGetGlobalSnapshotResult_, err error) {
+	ctx = client.NewCtxWithCallOptions(ctx, callOptions)
+	return p.kClient.GetGlobalSnapshot(ctx, request)
 }
 
 func (p *kFrontendServiceClient) RestoreSnapshot(ctx context.Context, request *frontendservice.TRestoreSnapshotRequest, callOptions ...callopt.Option) (r *frontendservice.TRestoreSnapshotResult_, err error) {

--- a/pkg/rpc/kitex_gen/frontendservice/frontendservice/frontendservice.go
+++ b/pkg/rpc/kitex_gen/frontendservice/frontendservice/frontendservice.go
@@ -46,6 +46,7 @@ func NewServiceInfo() *kitex.ServiceInfo {
 		"rollbackTxn":               kitex.NewMethodInfo(rollbackTxnHandler, newFrontendServiceRollbackTxnArgs, newFrontendServiceRollbackTxnResult, false),
 		"getBinlog":                 kitex.NewMethodInfo(getBinlogHandler, newFrontendServiceGetBinlogArgs, newFrontendServiceGetBinlogResult, false),
 		"getSnapshot":               kitex.NewMethodInfo(getSnapshotHandler, newFrontendServiceGetSnapshotArgs, newFrontendServiceGetSnapshotResult, false),
+		"getGlobalSnapshot":         kitex.NewMethodInfo(getGlobalSnapshotHandler, newFrontendServiceGetGlobalSnapshotArgs, newFrontendServiceGetGlobalSnapshotResult, false),
 		"restoreSnapshot":           kitex.NewMethodInfo(restoreSnapshotHandler, newFrontendServiceRestoreSnapshotArgs, newFrontendServiceRestoreSnapshotResult, false),
 		"lockBinlog":                kitex.NewMethodInfo(lockBinlogHandler, newFrontendServiceLockBinlogArgs, newFrontendServiceLockBinlogResult, false),
 		"waitingTxnStatus":          kitex.NewMethodInfo(waitingTxnStatusHandler, newFrontendServiceWaitingTxnStatusArgs, newFrontendServiceWaitingTxnStatusResult, false),
@@ -547,6 +548,24 @@ func newFrontendServiceGetSnapshotArgs() interface{} {
 
 func newFrontendServiceGetSnapshotResult() interface{} {
 	return frontendservice.NewFrontendServiceGetSnapshotResult()
+}
+
+func getGlobalSnapshotHandler(ctx context.Context, handler interface{}, arg, result interface{}) error {
+	realArg := arg.(*frontendservice.FrontendServiceGetGlobalSnapshotArgs)
+	realResult := result.(*frontendservice.FrontendServiceGetGlobalSnapshotResult)
+	success, err := handler.(frontendservice.FrontendService).GetGlobalSnapshot(ctx, realArg.Request)
+	if err != nil {
+		return err
+	}
+	realResult.Success = success
+	return nil
+}
+func newFrontendServiceGetGlobalSnapshotArgs() interface{} {
+	return frontendservice.NewFrontendServiceGetGlobalSnapshotArgs()
+}
+
+func newFrontendServiceGetGlobalSnapshotResult() interface{} {
+	return frontendservice.NewFrontendServiceGetGlobalSnapshotResult()
 }
 
 func restoreSnapshotHandler(ctx context.Context, handler interface{}, arg, result interface{}) error {
@@ -1469,6 +1488,16 @@ func (p *kClient) GetSnapshot(ctx context.Context, request *frontendservice.TGet
 	_args.Request = request
 	var _result frontendservice.FrontendServiceGetSnapshotResult
 	if err = p.c.Call(ctx, "getSnapshot", &_args, &_result); err != nil {
+		return
+	}
+	return _result.GetSuccess(), nil
+}
+
+func (p *kClient) GetGlobalSnapshot(ctx context.Context, request *frontendservice.TGetGlobalSnapshotRequest) (r *frontendservice.TGetGlobalSnapshotResult_, err error) {
+	var _args frontendservice.FrontendServiceGetGlobalSnapshotArgs
+	_args.Request = request
+	var _result frontendservice.FrontendServiceGetGlobalSnapshotResult
+	if err = p.c.Call(ctx, "getGlobalSnapshot", &_args, &_result); err != nil {
 		return
 	}
 	return _result.GetSuccess(), nil

--- a/pkg/rpc/kitex_gen/frontendservice/k-FrontendService.go
+++ b/pkg/rpc/kitex_gen/frontendservice/k-FrontendService.go
@@ -38865,6 +38865,781 @@ func (p *TGetSnapshotResult_) field7Length() int {
 	return l
 }
 
+func (p *TGetGlobalSnapshotRequest) FastRead(buf []byte) (int, error) {
+	var err error
+	var offset int
+	var l int
+	var fieldTypeId thrift.TType
+	var fieldId int16
+	_, l, err = bthrift.Binary.ReadStructBegin(buf)
+	offset += l
+	if err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, l, err = bthrift.Binary.ReadFieldBegin(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField1(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 2:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField2(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 3:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField3(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 4:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField4(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 5:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField5(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 6:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField6(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 7:
+			if fieldTypeId == thrift.I32 {
+				l, err = p.FastReadField7(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		default:
+			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+			offset += l
+			if err != nil {
+				goto SkipFieldError
+			}
+		}
+
+		l, err = bthrift.Binary.ReadFieldEnd(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	l, err = bthrift.Binary.ReadStructEnd(buf[offset:])
+	offset += l
+	if err != nil {
+		goto ReadStructEndError
+	}
+
+	return offset, nil
+ReadStructBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_TGetGlobalSnapshotRequest[fieldId]), err)
+SkipFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+ReadFieldEndError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotRequest) FastReadField1(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.Cluster = &v
+
+	}
+	return offset, nil
+}
+
+func (p *TGetGlobalSnapshotRequest) FastReadField2(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.User = &v
+
+	}
+	return offset, nil
+}
+
+func (p *TGetGlobalSnapshotRequest) FastReadField3(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.Passwd = &v
+
+	}
+	return offset, nil
+}
+
+func (p *TGetGlobalSnapshotRequest) FastReadField4(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.Token = &v
+
+	}
+	return offset, nil
+}
+
+func (p *TGetGlobalSnapshotRequest) FastReadField5(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.LabelName = &v
+
+	}
+	return offset, nil
+}
+
+func (p *TGetGlobalSnapshotRequest) FastReadField6(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.SnapshotName = &v
+
+	}
+	return offset, nil
+}
+
+func (p *TGetGlobalSnapshotRequest) FastReadField7(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI32(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+
+		tmp := TSnapshotType(v)
+		p.SnapshotType = &tmp
+
+	}
+	return offset, nil
+}
+
+// for compatibility
+func (p *TGetGlobalSnapshotRequest) FastWrite(buf []byte) int {
+	return 0
+}
+
+func (p *TGetGlobalSnapshotRequest) FastWriteNocopy(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	offset += bthrift.Binary.WriteStructBegin(buf[offset:], "TGetGlobalSnapshotRequest")
+	if p != nil {
+		offset += p.fastWriteField1(buf[offset:], binaryWriter)
+		offset += p.fastWriteField2(buf[offset:], binaryWriter)
+		offset += p.fastWriteField3(buf[offset:], binaryWriter)
+		offset += p.fastWriteField4(buf[offset:], binaryWriter)
+		offset += p.fastWriteField5(buf[offset:], binaryWriter)
+		offset += p.fastWriteField6(buf[offset:], binaryWriter)
+		offset += p.fastWriteField7(buf[offset:], binaryWriter)
+	}
+	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
+	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
+	return offset
+}
+
+func (p *TGetGlobalSnapshotRequest) BLength() int {
+	l := 0
+	l += bthrift.Binary.StructBeginLength("TGetGlobalSnapshotRequest")
+	if p != nil {
+		l += p.field1Length()
+		l += p.field2Length()
+		l += p.field3Length()
+		l += p.field4Length()
+		l += p.field5Length()
+		l += p.field6Length()
+		l += p.field7Length()
+	}
+	l += bthrift.Binary.FieldStopLength()
+	l += bthrift.Binary.StructEndLength()
+	return l
+}
+
+func (p *TGetGlobalSnapshotRequest) fastWriteField1(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetCluster() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "cluster", thrift.STRING, 1)
+		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.Cluster)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotRequest) fastWriteField2(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetUser() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "user", thrift.STRING, 2)
+		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.User)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotRequest) fastWriteField3(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetPasswd() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "passwd", thrift.STRING, 3)
+		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.Passwd)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotRequest) fastWriteField4(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetToken() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "token", thrift.STRING, 4)
+		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.Token)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotRequest) fastWriteField5(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetLabelName() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "label_name", thrift.STRING, 5)
+		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.LabelName)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotRequest) fastWriteField6(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetSnapshotName() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "snapshot_name", thrift.STRING, 6)
+		offset += bthrift.Binary.WriteStringNocopy(buf[offset:], binaryWriter, *p.SnapshotName)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotRequest) fastWriteField7(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetSnapshotType() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "snapshot_type", thrift.I32, 7)
+		offset += bthrift.Binary.WriteI32(buf[offset:], int32(*p.SnapshotType))
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotRequest) field1Length() int {
+	l := 0
+	if p.IsSetCluster() {
+		l += bthrift.Binary.FieldBeginLength("cluster", thrift.STRING, 1)
+		l += bthrift.Binary.StringLengthNocopy(*p.Cluster)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetGlobalSnapshotRequest) field2Length() int {
+	l := 0
+	if p.IsSetUser() {
+		l += bthrift.Binary.FieldBeginLength("user", thrift.STRING, 2)
+		l += bthrift.Binary.StringLengthNocopy(*p.User)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetGlobalSnapshotRequest) field3Length() int {
+	l := 0
+	if p.IsSetPasswd() {
+		l += bthrift.Binary.FieldBeginLength("passwd", thrift.STRING, 3)
+		l += bthrift.Binary.StringLengthNocopy(*p.Passwd)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetGlobalSnapshotRequest) field4Length() int {
+	l := 0
+	if p.IsSetToken() {
+		l += bthrift.Binary.FieldBeginLength("token", thrift.STRING, 4)
+		l += bthrift.Binary.StringLengthNocopy(*p.Token)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetGlobalSnapshotRequest) field5Length() int {
+	l := 0
+	if p.IsSetLabelName() {
+		l += bthrift.Binary.FieldBeginLength("label_name", thrift.STRING, 5)
+		l += bthrift.Binary.StringLengthNocopy(*p.LabelName)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetGlobalSnapshotRequest) field6Length() int {
+	l := 0
+	if p.IsSetSnapshotName() {
+		l += bthrift.Binary.FieldBeginLength("snapshot_name", thrift.STRING, 6)
+		l += bthrift.Binary.StringLengthNocopy(*p.SnapshotName)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetGlobalSnapshotRequest) field7Length() int {
+	l := 0
+	if p.IsSetSnapshotType() {
+		l += bthrift.Binary.FieldBeginLength("snapshot_type", thrift.I32, 7)
+		l += bthrift.Binary.I32Length(int32(*p.SnapshotType))
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetGlobalSnapshotResult_) FastRead(buf []byte) (int, error) {
+	var err error
+	var offset int
+	var l int
+	var fieldTypeId thrift.TType
+	var fieldId int16
+	_, l, err = bthrift.Binary.ReadStructBegin(buf)
+	offset += l
+	if err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, l, err = bthrift.Binary.ReadFieldBegin(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				l, err = p.FastReadField1(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 2:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField2(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 3:
+			if fieldTypeId == thrift.STRUCT {
+				l, err = p.FastReadField3(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 4:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField4(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 5:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField5(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		default:
+			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+			offset += l
+			if err != nil {
+				goto SkipFieldError
+			}
+		}
+
+		l, err = bthrift.Binary.ReadFieldEnd(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	l, err = bthrift.Binary.ReadStructEnd(buf[offset:])
+	offset += l
+	if err != nil {
+		goto ReadStructEndError
+	}
+
+	return offset, nil
+ReadStructBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_TGetGlobalSnapshotResult_[fieldId]), err)
+SkipFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+ReadFieldEndError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *TGetGlobalSnapshotResult_) FastReadField1(buf []byte) (int, error) {
+	offset := 0
+
+	tmp := status.NewTStatus()
+	if l, err := tmp.FastRead(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	p.Status = tmp
+	return offset, nil
+}
+
+func (p *TGetGlobalSnapshotResult_) FastReadField2(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadBinary(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+
+		p.GlobalInfo = []byte(v)
+
+	}
+	return offset, nil
+}
+
+func (p *TGetGlobalSnapshotResult_) FastReadField3(buf []byte) (int, error) {
+	offset := 0
+
+	tmp := types.NewTNetworkAddress()
+	if l, err := tmp.FastRead(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	p.MasterAddress = tmp
+	return offset, nil
+}
+
+func (p *TGetGlobalSnapshotResult_) FastReadField4(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.ExpiredAt = &v
+
+	}
+	return offset, nil
+}
+
+func (p *TGetGlobalSnapshotResult_) FastReadField5(buf []byte) (int, error) {
+	offset := 0
+
+	if v, l, err := bthrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		p.CommitSeq = &v
+
+	}
+	return offset, nil
+}
+
+// for compatibility
+func (p *TGetGlobalSnapshotResult_) FastWrite(buf []byte) int {
+	return 0
+}
+
+func (p *TGetGlobalSnapshotResult_) FastWriteNocopy(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	offset += bthrift.Binary.WriteStructBegin(buf[offset:], "TGetGlobalSnapshotResult")
+	if p != nil {
+		offset += p.fastWriteField4(buf[offset:], binaryWriter)
+		offset += p.fastWriteField5(buf[offset:], binaryWriter)
+		offset += p.fastWriteField1(buf[offset:], binaryWriter)
+		offset += p.fastWriteField2(buf[offset:], binaryWriter)
+		offset += p.fastWriteField3(buf[offset:], binaryWriter)
+	}
+	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
+	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
+	return offset
+}
+
+func (p *TGetGlobalSnapshotResult_) BLength() int {
+	l := 0
+	l += bthrift.Binary.StructBeginLength("TGetGlobalSnapshotResult")
+	if p != nil {
+		l += p.field1Length()
+		l += p.field2Length()
+		l += p.field3Length()
+		l += p.field4Length()
+		l += p.field5Length()
+	}
+	l += bthrift.Binary.FieldStopLength()
+	l += bthrift.Binary.StructEndLength()
+	return l
+}
+
+func (p *TGetGlobalSnapshotResult_) fastWriteField1(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetStatus() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "status", thrift.STRUCT, 1)
+		offset += p.Status.FastWriteNocopy(buf[offset:], binaryWriter)
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotResult_) fastWriteField2(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetGlobalInfo() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "global_info", thrift.STRING, 2)
+		offset += bthrift.Binary.WriteBinaryNocopy(buf[offset:], binaryWriter, []byte(p.GlobalInfo))
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotResult_) fastWriteField3(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetMasterAddress() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "master_address", thrift.STRUCT, 3)
+		offset += p.MasterAddress.FastWriteNocopy(buf[offset:], binaryWriter)
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotResult_) fastWriteField4(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetExpiredAt() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "expiredAt", thrift.I64, 4)
+		offset += bthrift.Binary.WriteI64(buf[offset:], *p.ExpiredAt)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotResult_) fastWriteField5(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetCommitSeq() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "commit_seq", thrift.I64, 5)
+		offset += bthrift.Binary.WriteI64(buf[offset:], *p.CommitSeq)
+
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *TGetGlobalSnapshotResult_) field1Length() int {
+	l := 0
+	if p.IsSetStatus() {
+		l += bthrift.Binary.FieldBeginLength("status", thrift.STRUCT, 1)
+		l += p.Status.BLength()
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetGlobalSnapshotResult_) field2Length() int {
+	l := 0
+	if p.IsSetGlobalInfo() {
+		l += bthrift.Binary.FieldBeginLength("global_info", thrift.STRING, 2)
+		l += bthrift.Binary.BinaryLengthNocopy([]byte(p.GlobalInfo))
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetGlobalSnapshotResult_) field3Length() int {
+	l := 0
+	if p.IsSetMasterAddress() {
+		l += bthrift.Binary.FieldBeginLength("master_address", thrift.STRUCT, 3)
+		l += p.MasterAddress.BLength()
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetGlobalSnapshotResult_) field4Length() int {
+	l := 0
+	if p.IsSetExpiredAt() {
+		l += bthrift.Binary.FieldBeginLength("expiredAt", thrift.I64, 4)
+		l += bthrift.Binary.I64Length(*p.ExpiredAt)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
+func (p *TGetGlobalSnapshotResult_) field5Length() int {
+	l := 0
+	if p.IsSetCommitSeq() {
+		l += bthrift.Binary.FieldBeginLength("commit_seq", thrift.I64, 5)
+		l += bthrift.Binary.I64Length(*p.CommitSeq)
+
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
 func (p *TTableRef) FastRead(buf []byte) (int, error) {
 	var err error
 	var offset int
@@ -60453,6 +61228,264 @@ func (p *FrontendServiceGetSnapshotResult) field0Length() int {
 	return l
 }
 
+func (p *FrontendServiceGetGlobalSnapshotArgs) FastRead(buf []byte) (int, error) {
+	var err error
+	var offset int
+	var l int
+	var fieldTypeId thrift.TType
+	var fieldId int16
+	_, l, err = bthrift.Binary.ReadStructBegin(buf)
+	offset += l
+	if err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, l, err = bthrift.Binary.ReadFieldBegin(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				l, err = p.FastReadField1(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		default:
+			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+			offset += l
+			if err != nil {
+				goto SkipFieldError
+			}
+		}
+
+		l, err = bthrift.Binary.ReadFieldEnd(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	l, err = bthrift.Binary.ReadStructEnd(buf[offset:])
+	offset += l
+	if err != nil {
+		goto ReadStructEndError
+	}
+
+	return offset, nil
+ReadStructBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_FrontendServiceGetGlobalSnapshotArgs[fieldId]), err)
+SkipFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+ReadFieldEndError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) FastReadField1(buf []byte) (int, error) {
+	offset := 0
+
+	tmp := NewTGetGlobalSnapshotRequest()
+	if l, err := tmp.FastRead(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	p.Request = tmp
+	return offset, nil
+}
+
+// for compatibility
+func (p *FrontendServiceGetGlobalSnapshotArgs) FastWrite(buf []byte) int {
+	return 0
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) FastWriteNocopy(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	offset += bthrift.Binary.WriteStructBegin(buf[offset:], "getGlobalSnapshot_args")
+	if p != nil {
+		offset += p.fastWriteField1(buf[offset:], binaryWriter)
+	}
+	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
+	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
+	return offset
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) BLength() int {
+	l := 0
+	l += bthrift.Binary.StructBeginLength("getGlobalSnapshot_args")
+	if p != nil {
+		l += p.field1Length()
+	}
+	l += bthrift.Binary.FieldStopLength()
+	l += bthrift.Binary.StructEndLength()
+	return l
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) fastWriteField1(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "request", thrift.STRUCT, 1)
+	offset += p.Request.FastWriteNocopy(buf[offset:], binaryWriter)
+	offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	return offset
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) field1Length() int {
+	l := 0
+	l += bthrift.Binary.FieldBeginLength("request", thrift.STRUCT, 1)
+	l += p.Request.BLength()
+	l += bthrift.Binary.FieldEndLength()
+	return l
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) FastRead(buf []byte) (int, error) {
+	var err error
+	var offset int
+	var l int
+	var fieldTypeId thrift.TType
+	var fieldId int16
+	_, l, err = bthrift.Binary.ReadStructBegin(buf)
+	offset += l
+	if err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, l, err = bthrift.Binary.ReadFieldBegin(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 0:
+			if fieldTypeId == thrift.STRUCT {
+				l, err = p.FastReadField0(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		default:
+			l, err = bthrift.Binary.Skip(buf[offset:], fieldTypeId)
+			offset += l
+			if err != nil {
+				goto SkipFieldError
+			}
+		}
+
+		l, err = bthrift.Binary.ReadFieldEnd(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	l, err = bthrift.Binary.ReadStructEnd(buf[offset:])
+	offset += l
+	if err != nil {
+		goto ReadStructEndError
+	}
+
+	return offset, nil
+ReadStructBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_FrontendServiceGetGlobalSnapshotResult[fieldId]), err)
+SkipFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+ReadFieldEndError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) FastReadField0(buf []byte) (int, error) {
+	offset := 0
+
+	tmp := NewTGetGlobalSnapshotResult_()
+	if l, err := tmp.FastRead(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	p.Success = tmp
+	return offset, nil
+}
+
+// for compatibility
+func (p *FrontendServiceGetGlobalSnapshotResult) FastWrite(buf []byte) int {
+	return 0
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) FastWriteNocopy(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	offset += bthrift.Binary.WriteStructBegin(buf[offset:], "getGlobalSnapshot_result")
+	if p != nil {
+		offset += p.fastWriteField0(buf[offset:], binaryWriter)
+	}
+	offset += bthrift.Binary.WriteFieldStop(buf[offset:])
+	offset += bthrift.Binary.WriteStructEnd(buf[offset:])
+	return offset
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) BLength() int {
+	l := 0
+	l += bthrift.Binary.StructBeginLength("getGlobalSnapshot_result")
+	if p != nil {
+		l += p.field0Length()
+	}
+	l += bthrift.Binary.FieldStopLength()
+	l += bthrift.Binary.StructEndLength()
+	return l
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) fastWriteField0(buf []byte, binaryWriter bthrift.BinaryWriter) int {
+	offset := 0
+	if p.IsSetSuccess() {
+		offset += bthrift.Binary.WriteFieldBegin(buf[offset:], "success", thrift.STRUCT, 0)
+		offset += p.Success.FastWriteNocopy(buf[offset:], binaryWriter)
+		offset += bthrift.Binary.WriteFieldEnd(buf[offset:])
+	}
+	return offset
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) field0Length() int {
+	l := 0
+	if p.IsSetSuccess() {
+		l += bthrift.Binary.FieldBeginLength("success", thrift.STRUCT, 0)
+		l += p.Success.BLength()
+		l += bthrift.Binary.FieldEndLength()
+	}
+	return l
+}
+
 func (p *FrontendServiceRestoreSnapshotArgs) FastRead(buf []byte) (int, error) {
 	var err error
 	var offset int
@@ -70151,6 +71184,14 @@ func (p *FrontendServiceGetSnapshotArgs) GetFirstArgument() interface{} {
 }
 
 func (p *FrontendServiceGetSnapshotResult) GetResult() interface{} {
+	return p.Success
+}
+
+func (p *FrontendServiceGetGlobalSnapshotArgs) GetFirstArgument() interface{} {
+	return p.Request
+}
+
+func (p *FrontendServiceGetGlobalSnapshotResult) GetResult() interface{} {
 	return p.Success
 }
 

--- a/pkg/rpc/thrift/FrontendService.thrift
+++ b/pkg/rpc/thrift/FrontendService.thrift
@@ -1197,6 +1197,24 @@ struct TGetSnapshotResult {
     7: optional i64 commit_seq;
 }
 
+struct TGetGlobalSnapshotRequest {
+    1: optional string cluster
+    2: optional string user
+    3: optional string passwd
+    4: optional string token
+    5: optional string label_name
+    6: optional string snapshot_name
+    7: optional TSnapshotType snapshot_type
+}
+
+struct TGetGlobalSnapshotResult {
+    1: optional Status.TStatus status
+    2: optional binary global_info
+    3: optional Types.TNetworkAddress master_address
+    4: optional i64 expiredAt;  // in millis
+    5: optional i64 commit_seq;
+}
+
 struct TTableRef {
     1: optional string table
     3: optional string alias_name
@@ -1590,6 +1608,7 @@ service FrontendService {
     TRollbackTxnResult rollbackTxn(1: TRollbackTxnRequest request)
     TGetBinlogResult getBinlog(1: TGetBinlogRequest request)
     TGetSnapshotResult getSnapshot(1: TGetSnapshotRequest request)
+    TGetGlobalSnapshotResult getGlobalSnapshot(1: TGetGlobalSnapshotRequest request)
     TRestoreSnapshotResult restoreSnapshot(1: TRestoreSnapshotRequest request)
     TLockBinlogResult lockBinlog(1: TLockBinlogRequest request)
 

--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -103,6 +103,8 @@ type CreateCcrRequest struct {
 	// For table sync, allow to create ccr job even if the target table already exists.
 	AllowTableExists bool `json:"allow_table_exists"`
 	ReuseBinlogLabel bool `json:"reuse_binlog_label"`
+	// 是否为集群级同步，如果为true，将获取源集群所有数据库并为每个数据库创建同步任务
+	ClusterSync bool `json:"cluster_sync"`
 }
 
 // Stringer
@@ -156,6 +158,245 @@ func createCcr(request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobMana
 	return nil
 }
 
+// createClusterCcr 创建集群级别的CCR同步任务
+// 获取源集群的所有数据库，为每个数据库创建一个同步任务
+func createClusterCcr(request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobManager) error {
+	log.Infof("create cluster ccr %s", request)
+
+	// 获取源集群的所有数据库列表
+	databases, err := getDatabaseList(&request.Src)
+	if err != nil {
+		return xerror.Wrapf(err, xerror.Normal, "Failed to get database list from source cluster")
+	}
+
+	if len(databases) == 0 {
+		return xerror.Errorf(xerror.Normal, "No databases found in source cluster")
+	}
+
+	log.Infof("Found %d databases, starting to create cluster-level sync tasks: %v", len(databases), databases)
+
+	var errors []string
+	successCount := 0
+
+	for _, dbName := range databases {
+		// 为每个数据库创建一个新的请求
+		dbRequest := &CreateCcrRequest{
+			Name:             fmt.Sprintf("%s_%s", request.Name, dbName), // 任务名称加上数据库名称
+			Src:              request.Src,
+			Dest:             request.Dest,
+			SkipError:        request.SkipError,
+			AllowTableExists: request.AllowTableExists,
+			ReuseBinlogLabel: request.ReuseBinlogLabel,
+			ClusterSync:      false, // 设置为false，避免递归调用
+		}
+
+		dbRequest.Src.Database = dbName
+		dbRequest.Dest.Database = dbName
+
+		if err := createCcr(dbRequest, db, jobManager); err != nil {
+			errMsg := fmt.Sprintf("Failed to create sync task for database %s: %v", dbName, err)
+			log.Warnf(errMsg)
+			errors = append(errors, errMsg)
+		} else {
+			successCount++
+			log.Infof("Successfully created sync task for database %s", dbName)
+		}
+	}
+
+	if len(errors) > 0 {
+		if successCount == 0 {
+			return xerror.Errorf(xerror.Normal, "All database sync tasks creation failed: %s", strings.Join(errors, "; "))
+		} else {
+			log.Warnf("Partial cluster sync tasks creation failed, success: %d, failed: %d, errors: %s",
+				successCount, len(errors), strings.Join(errors, "; "))
+		}
+	}
+
+	log.Infof("Cluster-level sync tasks creation completed, success: %d, failed: %d", successCount, len(errors))
+
+	// 启动守护任务，周期性检测源集群新增数据库，传入已有的数据库列表
+	go startDatabaseMonitor(request, db, jobManager, databases)
+
+	return nil
+}
+
+// startDatabaseMonitor 启动一个守护任务，周期性检测源集群新增和删除的数据库，并创建或删除对应的同步任务
+func startDatabaseMonitor(request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobManager, initialDatabases []string) {
+	log.Infof("Starting database monitor daemon, task name prefix: %s", request.Name)
+
+	existingDatabases := initializeDatabaseTracking(initialDatabases)
+	log.Infof("Initialized database monitoring, currently have %d databases", len(existingDatabases))
+
+	checkInterval := 2 * time.Minute
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		monitorDatabaseChanges(request, db, jobManager, existingDatabases)
+	}
+}
+
+func initializeDatabaseTracking(initialDatabases []string) map[string]bool {
+	existingDatabases := make(map[string]bool)
+	for _, dbName := range initialDatabases {
+		existingDatabases[dbName] = true
+	}
+	return existingDatabases
+}
+
+// monitorDatabaseChanges 检测数据库变化并处理
+func monitorDatabaseChanges(request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobManager, existingDatabases map[string]bool) {
+	currentDatabases, err := request.Src.GetAllDatabases()
+	if err != nil {
+		log.Errorf("Failed to get database list: %v", err)
+		return
+	}
+
+	currentDatabaseMap := make(map[string]bool)
+	for _, dbName := range currentDatabases {
+		if dbName == "" {
+			continue
+		}
+		currentDatabaseMap[dbName] = true
+	}
+
+	newDatabases := identifyNewDatabases(currentDatabases, existingDatabases)
+	deletedDatabases := identifyDeletedDatabases(existingDatabases, currentDatabaseMap)
+
+	handleNewDatabases(newDatabases, request, db, jobManager)
+	handleDeletedDatabases(deletedDatabases, request, jobManager)
+	logMonitoringStatus(newDatabases, deletedDatabases, existingDatabases)
+}
+
+func identifyNewDatabases(currentDatabases []string, existingDatabases map[string]bool) []string {
+	var newDatabases []string
+	for _, dbName := range currentDatabases {
+		if !existingDatabases[dbName] {
+			newDatabases = append(newDatabases, dbName)
+			existingDatabases[dbName] = true
+		}
+	}
+	return newDatabases
+}
+
+func identifyDeletedDatabases(existingDatabases map[string]bool, currentDatabaseMap map[string]bool) []string {
+	var deletedDatabases []string
+	for dbName := range existingDatabases {
+		if !currentDatabaseMap[dbName] {
+			deletedDatabases = append(deletedDatabases, dbName)
+			delete(existingDatabases, dbName)
+		}
+	}
+	return deletedDatabases
+}
+
+func handleNewDatabases(newDatabases []string, request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobManager) {
+	if len(newDatabases) == 0 {
+		return
+	}
+
+	log.Infof("Found %d new databases: %v", len(newDatabases), newDatabases)
+
+	for _, dbName := range newDatabases {
+		if dbName == "" {
+			log.Warnf("Skipping empty database name")
+			continue
+		}
+
+		jobName := fmt.Sprintf("%s_%s", request.Name, dbName)
+		jobExists, err := db.IsJobExist(jobName)
+		if err != nil {
+			log.Warnf("Error checking if job %s exists: %v", jobName, err)
+			continue
+		}
+
+		if jobExists {
+			log.Warnf("Job %s already exists, skipping sync task creation for database %s", jobName, dbName)
+			continue
+		}
+
+		dbRequest := &CreateCcrRequest{
+			Name:             jobName,
+			Src:              request.Src,
+			Dest:             request.Dest,
+			SkipError:        request.SkipError,
+			AllowTableExists: request.AllowTableExists,
+			ReuseBinlogLabel: request.ReuseBinlogLabel,
+			ClusterSync:      false, // 设置为false，避免递归调用
+		}
+
+		dbRequest.Src.Database = dbName
+		dbRequest.Dest.Database = dbName
+
+		maxRetries := 3
+		for i := 0; i < maxRetries; i++ {
+			if err := createCcr(dbRequest, db, jobManager); err != nil {
+				if i == maxRetries-1 {
+					log.Warnf("Failed to create sync task for new database %s (attempt %d/%d): %v", dbName, i+1, maxRetries, err)
+				} else {
+					log.Warnf("Failed to create sync task for new database %s (attempt %d/%d): %v, will retry", dbName, i+1, maxRetries, err)
+					time.Sleep(time.Second * time.Duration(i+1)) // 指数退避
+				}
+			} else {
+				log.Infof("Successfully created sync task for new database %s", dbName)
+				break
+			}
+		}
+	}
+}
+
+func handleDeletedDatabases(deletedDatabases []string, request *CreateCcrRequest, jobManager *ccr.JobManager) {
+	if len(deletedDatabases) == 0 {
+		return
+	}
+
+	log.Infof("Found %d deleted databases: %v", len(deletedDatabases), deletedDatabases)
+
+	for _, dbName := range deletedDatabases {
+		if dbName == "" {
+			log.Warnf("Skipping empty database name")
+			continue
+		}
+
+		jobName := fmt.Sprintf("%s_%s", request.Name, dbName)
+
+		maxRetries := 3
+		for i := 0; i < maxRetries; i++ {
+			if err := jobManager.RemoveJob(jobName); err != nil {
+				if i == maxRetries-1 {
+					log.Warnf("Failed to remove sync task for deleted database %s (attempt %d/%d): %v", dbName, i+1, maxRetries, err)
+				} else {
+					log.Warnf("Failed to remove sync task for deleted database %s (attempt %d/%d): %v, will retry", dbName, i+1, maxRetries, err)
+					time.Sleep(time.Second * time.Duration(i+1)) // 指数退避
+				}
+			} else {
+				log.Infof("Successfully removed sync task for deleted database %s", dbName)
+				break
+			}
+		}
+	}
+}
+
+// logMonitoringStatus 记录监控状态
+func logMonitoringStatus(newDatabases []string, deletedDatabases []string, existingDatabases map[string]bool) {
+	if len(newDatabases) == 0 && len(deletedDatabases) == 0 {
+		log.Infof("No database changes detected, currently have %d databases", len(existingDatabases))
+	}
+}
+
+func getDatabaseList(spec *base.Spec) ([]string, error) {
+	log.Infof("Getting database list for cluster %s", spec.Host)
+
+	// 使用Specer接口的GetAllDatabases方法
+	databases, err := spec.GetAllDatabases()
+	if err != nil {
+		return nil, xerror.Wrapf(err, xerror.Normal, "Failed to get database list")
+	}
+
+	log.Infof("Got %d user databases: %v", len(databases), databases)
+	return databases, nil
+}
+
 // return exit(bool)
 func (s *HttpService) redirect(jobName string, w http.ResponseWriter, r *http.Request) bool {
 	if jobExist, err := s.db.IsJobExist(jobName); err != nil {
@@ -205,12 +446,20 @@ func (s *HttpService) createHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Call the createCcr function to create the CCR
-	if err = createCcr(&request, s.db, s.jobManager); err != nil {
-		log.Warnf("create ccr failed: %+v", err)
-		createResult = newErrorResult(err.Error())
+	if request.ClusterSync {
+		if err = createClusterCcr(&request, s.db, s.jobManager); err != nil {
+			log.Warnf("create cluster ccr failed: %+v", err)
+			createResult = newErrorResult(err.Error())
+		} else {
+			createResult = newSuccessResult()
+		}
 	} else {
-		createResult = newSuccessResult()
+		if err = createCcr(&request, s.db, s.jobManager); err != nil {
+			log.Warnf("create ccr failed: %+v", err)
+			createResult = newErrorResult(err.Error())
+		} else {
+			createResult = newSuccessResult()
+		}
 	}
 }
 

--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -40,6 +40,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Global sync related constants
+const (
+	MAX_CHECK_RETRY_TIMES = 20
+	BACKUP_CHECK_DURATION = 5 * time.Second
+)
+
 // TODO(Drogon): impl a generic http request handle parse json
 
 func writeJson(w http.ResponseWriter, data interface{}) {
@@ -103,7 +109,7 @@ type CreateCcrRequest struct {
 	// For table sync, allow to create ccr job even if the target table already exists.
 	AllowTableExists bool `json:"allow_table_exists"`
 	ReuseBinlogLabel bool `json:"reuse_binlog_label"`
-	// 是否为集群级同步，如果为true，将获取源集群所有数据库并为每个数据库创建同步任务
+	// Whether it's cluster-level sync, if true, will get all databases from source cluster and create sync task for each database
 	ClusterSync bool `json:"cluster_sync"`
 }
 
@@ -158,12 +164,12 @@ func createCcr(request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobMana
 	return nil
 }
 
-// createClusterCcr 创建集群级别的CCR同步任务
-// 获取源集群的所有数据库，为每个数据库创建一个同步任务
+// createClusterCcr creates cluster-level CCR sync tasks
+// Gets all databases from source cluster and creates a sync task for each database
 func createClusterCcr(request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobManager) error {
 	log.Infof("create cluster ccr %s", request)
 
-	// 获取源集群的所有数据库列表
+	// Get all database list from source cluster
 	databases, err := getDatabaseList(&request.Src)
 	if err != nil {
 		return xerror.Wrapf(err, xerror.Normal, "Failed to get database list from source cluster")
@@ -179,15 +185,15 @@ func createClusterCcr(request *CreateCcrRequest, db storage.DB, jobManager *ccr.
 	successCount := 0
 
 	for _, dbName := range databases {
-		// 为每个数据库创建一个新的请求
+		// Create a new request for each database
 		dbRequest := &CreateCcrRequest{
-			Name:             fmt.Sprintf("%s_%s", request.Name, dbName), // 任务名称加上数据库名称
+			Name:             fmt.Sprintf("%s_%s", request.Name, dbName), // Task name with database name
 			Src:              request.Src,
 			Dest:             request.Dest,
 			SkipError:        request.SkipError,
 			AllowTableExists: request.AllowTableExists,
 			ReuseBinlogLabel: request.ReuseBinlogLabel,
-			ClusterSync:      false, // 设置为false，避免递归调用
+			ClusterSync:      false, // Set to false to avoid recursive calls
 		}
 
 		dbRequest.Src.Database = dbName
@@ -214,13 +220,13 @@ func createClusterCcr(request *CreateCcrRequest, db storage.DB, jobManager *ccr.
 
 	log.Infof("Cluster-level sync tasks creation completed, success: %d, failed: %d", successCount, len(errors))
 
-	// 启动守护任务，周期性检测源集群新增数据库，传入已有的数据库列表
+	// Start daemon task to periodically detect new databases in source cluster, pass existing database list
 	go startDatabaseMonitor(request, db, jobManager, databases)
 
 	return nil
 }
 
-// startDatabaseMonitor 启动一个守护任务，周期性检测源集群新增和删除的数据库，并创建或删除对应的同步任务
+// startDatabaseMonitor starts a daemon task to periodically detect new and deleted databases in source cluster, and create or delete corresponding sync tasks
 func startDatabaseMonitor(request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobManager, initialDatabases []string) {
 	log.Infof("Starting database monitor daemon, task name prefix: %s", request.Name)
 
@@ -244,7 +250,7 @@ func initializeDatabaseTracking(initialDatabases []string) map[string]bool {
 	return existingDatabases
 }
 
-// monitorDatabaseChanges 检测数据库变化并处理
+// monitorDatabaseChanges detects database changes and handles them
 func monitorDatabaseChanges(request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobManager, existingDatabases map[string]bool) {
 	currentDatabases, err := request.Src.GetAllDatabases()
 	if err != nil {
@@ -322,7 +328,7 @@ func handleNewDatabases(newDatabases []string, request *CreateCcrRequest, db sto
 			SkipError:        request.SkipError,
 			AllowTableExists: request.AllowTableExists,
 			ReuseBinlogLabel: request.ReuseBinlogLabel,
-			ClusterSync:      false, // 设置为false，避免递归调用
+			ClusterSync:      false, // Set to false to avoid recursive calls
 		}
 
 		dbRequest.Src.Database = dbName
@@ -332,10 +338,12 @@ func handleNewDatabases(newDatabases []string, request *CreateCcrRequest, db sto
 		for i := 0; i < maxRetries; i++ {
 			if err := createCcr(dbRequest, db, jobManager); err != nil {
 				if i == maxRetries-1 {
-					log.Warnf("Failed to create sync task for new database %s (attempt %d/%d): %v", dbName, i+1, maxRetries, err)
+					log.Warnf("Failed to create sync task for new database %s (attempt %d/%d): %v",
+						dbName, i+1, maxRetries, err)
 				} else {
-					log.Warnf("Failed to create sync task for new database %s (attempt %d/%d): %v, will retry", dbName, i+1, maxRetries, err)
-					time.Sleep(time.Second * time.Duration(i+1)) // 指数退避
+					log.Warnf("Failed to create sync task for new database %s (attempt %d/%d): %v, will retry",
+						dbName, i+1, maxRetries, err)
+					time.Sleep(time.Second * time.Duration(i+1)) // Exponential backoff
 				}
 			} else {
 				log.Infof("Successfully created sync task for new database %s", dbName)
@@ -367,7 +375,7 @@ func handleDeletedDatabases(deletedDatabases []string, request *CreateCcrRequest
 					log.Warnf("Failed to remove sync task for deleted database %s (attempt %d/%d): %v", dbName, i+1, maxRetries, err)
 				} else {
 					log.Warnf("Failed to remove sync task for deleted database %s (attempt %d/%d): %v, will retry", dbName, i+1, maxRetries, err)
-					time.Sleep(time.Second * time.Duration(i+1)) // 指数退避
+					time.Sleep(time.Second * time.Duration(i+1)) // Exponential backoff
 				}
 			} else {
 				log.Infof("Successfully removed sync task for deleted database %s", dbName)
@@ -377,7 +385,7 @@ func handleDeletedDatabases(deletedDatabases []string, request *CreateCcrRequest
 	}
 }
 
-// logMonitoringStatus 记录监控状态
+// logMonitoringStatus logs monitoring status
 func logMonitoringStatus(newDatabases []string, deletedDatabases []string, existingDatabases map[string]bool) {
 	if len(newDatabases) == 0 && len(deletedDatabases) == 0 {
 		log.Infof("No database changes detected, currently have %d databases", len(existingDatabases))
@@ -387,7 +395,7 @@ func logMonitoringStatus(newDatabases []string, deletedDatabases []string, exist
 func getDatabaseList(spec *base.Spec) ([]string, error) {
 	log.Infof("Getting database list for cluster %s", spec.Host)
 
-	// 使用Specer接口的GetAllDatabases方法
+	// Use Specer interface's GetAllDatabases method
 	databases, err := spec.GetAllDatabases()
 	if err != nil {
 		return nil, xerror.Wrapf(err, xerror.Normal, "Failed to get database list")
@@ -1333,9 +1341,195 @@ func (s *HttpService) failpointHandler(w http.ResponseWriter, r *http.Request) {
 	result = newSuccessResult()
 }
 
+// SyncGlobalRequest defines the structure of global sync request
+type SyncGlobalRequest struct {
+	// Required fields
+	Name string    `json:"name"`
+	Src  base.Spec `json:"src"`
+	Dest base.Spec `json:"dest"`
+	// Optional fields
+	All                 bool `json:"all"`
+	BackupPrivilege     bool `json:"backup_privilege"`
+	BackupCatalog       bool `json:"backup_catalog"`
+	BackupWorkloadGroup bool `json:"backup_workload_group"`
+}
+
+// Validate SyncGlobalRequest to ensure only one optional field is true
+func (r *SyncGlobalRequest) validate() error {
+	// Check required fields
+	if r.Name == "" {
+		return xerror.Errorf(xerror.Normal, "name is required")
+	}
+
+	// Check optional fields logic:
+	// If 'all' is set, other options don't need to be checked
+	// If 'all' is not set, other options can be set freely (multiple or none)
+	if r.All {
+		// If 'all' is set, validation passes regardless of other options
+		return nil
+	}
+
+	// If 'all' is not set, check if at least one other option is set
+	if !r.BackupPrivilege && !r.BackupCatalog && !r.BackupWorkloadGroup {
+		return xerror.Errorf(xerror.Normal, "Must specify at least one sync option: all, backup_privilege, backup_catalog, backup_workload_group")
+	}
+
+	return nil
+}
+
+// String method implements Stringer interface
+func (r *SyncGlobalRequest) String() string {
+	return fmt.Sprintf("name: %s, src: %v, dest: %v, all: %v, backup_privilege: %v, backup_catalog: %v, backup_workload_group: %v",
+		r.Name, r.Src, r.Dest, r.All, r.BackupPrivilege, r.BackupCatalog, r.BackupWorkloadGroup)
+}
+
+// syncGlobal executes global sync operation
+// createGlobalSnapshot creates a global snapshot on the source cluster
+func createGlobalSnapshot(request *SyncGlobalRequest) error {
+	log.Infof("Creating global snapshot %s", request.Name)
+
+	err := request.Src.CreateGlobalSnapshot(
+		request.Name,
+		request.BackupPrivilege,
+		request.BackupCatalog,
+		request.BackupWorkloadGroup,
+	)
+	if err != nil {
+		return xerror.Wrapf(err, xerror.Normal, "Failed to create global snapshot")
+	}
+
+	return nil
+}
+
+// waitForGlobalBackupCompletion waits for the global backup to complete
+func waitForGlobalBackupCompletion(request *SyncGlobalRequest) error {
+	log.Infof("Waiting for global backup %s to complete", request.Name)
+
+	for i := 0; i < MAX_CHECK_RETRY_TIMES; i++ {
+		finished, err := request.Src.CheckGlobalBackupFinished(request.Name)
+		if err != nil {
+			return xerror.Wrapf(err, xerror.Normal, "Failed to check global backup status")
+		}
+
+		if finished {
+			log.Infof("Global backup %s completed", request.Name)
+			return nil
+		}
+
+		time.Sleep(BACKUP_CHECK_DURATION)
+	}
+
+	return xerror.Errorf(xerror.Normal, "Timeout waiting for global backup completion, max retry times: %d", MAX_CHECK_RETRY_TIMES)
+}
+
+// processGlobalSnapshotInfo retrieves and processes global snapshot information
+func processGlobalSnapshotInfo(request *SyncGlobalRequest) error {
+	log.Infof("Getting global snapshot %s details", request.Name)
+
+	feRpc, err := rpc.NewFeRpc(&request.Src)
+	if err != nil {
+		log.Warnf("Failed to create FE RPC client: %+v", err)
+		// Don't return error because backup has completed successfully
+		return nil
+	}
+
+	snapshot, err := feRpc.GetGlobalSnapshot(&request.Src, request.Name)
+	if err != nil {
+		log.Warnf("Failed to get global snapshot details: %+v", err)
+		// Don't return error because backup has completed successfully
+		return nil
+	}
+
+	log.Infof("Global snapshot details: %+v", snapshot)
+
+	if snapshot.GlobalInfo == nil {
+		log.Warnf("Global snapshot information is empty")
+		return nil
+	}
+
+	return executeGlobalSnapshotSQL(request, snapshot.GlobalInfo)
+}
+
+// executeGlobalSnapshotSQL converts and executes global snapshot SQL statements
+func executeGlobalSnapshotSQL(request *SyncGlobalRequest, globalInfo []byte) error {
+	// GlobalInfo contains SQL statements, not JSON format
+	sqlStatements, err := ccr.NewBackupSqlsFromBytes(globalInfo)
+	if err != nil {
+		log.Warnf("Failed to convert global snapshot SQL statements: %+v", err)
+		return nil // Don't return error as this is not critical
+	}
+
+	log.Infof("Global snapshot SQL statements: %s", sqlStatements)
+
+	// Call RestoreGlobalInfo function to execute corresponding SQL on dest cluster
+	err = request.Dest.RestoreGlobalInfo(sqlStatements)
+	if err != nil {
+		log.Errorf("Failed to execute global snapshot SQL: %+v", err)
+		return err
+	}
+
+	log.Infof("Global snapshot SQL executed successfully")
+	return nil
+}
+
+// syncGlobal executes global sync operation
+func syncGlobal(request *SyncGlobalRequest) error {
+	log.Infof("Executing global sync %s", request)
+
+	// Step 1: Create global snapshot
+	if err := createGlobalSnapshot(request); err != nil {
+		return err
+	}
+
+	// Step 2: Wait for backup completion
+	if err := waitForGlobalBackupCompletion(request); err != nil {
+		return err
+	}
+
+	// Step 3: Process snapshot information and execute SQL
+	if err := processGlobalSnapshotInfo(request); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// syncGlobalHandler handles global sync requests
+func (s *HttpService) syncGlobalHandler(w http.ResponseWriter, r *http.Request) {
+	log.Infof("Global sync request")
+
+	var syncResult *defaultResult
+	defer func() { writeJson(w, syncResult) }()
+
+	// Parse JSON request body
+	var request SyncGlobalRequest
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		log.Warnf("Failed to parse global sync request: %+v", err)
+		syncResult = newErrorResult(err.Error())
+		return
+	}
+
+	// Validate request
+	if err = request.validate(); err != nil {
+		log.Warnf("Global sync request validation failed: %+v", err)
+		syncResult = newErrorResult(err.Error())
+		return
+	}
+
+	// Execute global sync
+	if err = syncGlobal(&request); err != nil {
+		log.Warnf("Global sync failed: %+v", err)
+		syncResult = newErrorResult(err.Error())
+	} else {
+		syncResult = newSuccessResult()
+	}
+}
+
 func (s *HttpService) RegisterHandlers() {
 	s.mux.HandleFunc("/version", s.versionHandler)
 	s.mux.HandleFunc("/create_ccr", s.createHandler)
+	s.mux.HandleFunc("/sync_global", s.syncGlobalHandler)
 	s.mux.HandleFunc("/pause", s.pauseHandler)
 	s.mux.HandleFunc("/resume", s.resumeHandler)
 	s.mux.HandleFunc("/delete", s.deleteHandler)


### PR DESCRIPTION
Add cluster-level CCR job creation.
By setting cluster_sync: true in the JSON body, a single POST to /create_ccr will automatically synchronize every database and table from the source cluster to the destination cluster
Usage example

curl -X POST -H "Content-Type: application/json" -d '{
  "name": "ccr_full",
  "cluster_sync": true,
  "src": {
    "host": "10.0.2.132",
    "port": "9030",
    "thrift_port": "9020",
    "user": "root",
    "password": "XX",
    "database": "",
    "table": ""
  },
  "dest": {
    "host": "10.0.4.252",
    "port": "9030",
    "thrift_port": "9020",
    "user": "root",
    "password": "XX",
    "database": "",
    "table": ""
  }
}' http://127.0.0.1:9190/create_ccr