### PR TITLE
tableRecord add delta rows

### DIFF
--- a/pkg/ccr/record/upsert.go
+++ b/pkg/ccr/record/upsert.go
@@ -44,7 +44,7 @@ type TableRecord struct {
 }
 
 func (t *TableRecord) String() string {
-	return fmt.Sprintf("TableRecord{Id: %d, PartitionRecords: %v, IndexIds: %v}", t.Id, t.PartitionRecords, t.IndexIds)
+	return fmt.Sprintf("TableRecord{Id: %d, PartitionRecords: %v, IndexIds: %v, DeltaRows: %v}", t.Id, t.PartitionRecords, t.IndexIds, t.DeltaRows)
 }
 
 type Upsert struct {


### PR DESCRIPTION
Added the missing DeltaRows field to the String() output so the debug log shows the complete state of a TableRecord.