### PR TITLE
feat: Support custom replication_num for downstream cluster

### DIFF
--- a/pkg/ccr/handle/create_table.go
+++ b/pkg/ccr/handle/create_table.go
@@ -73,6 +73,10 @@ func (h *CreateTableHandle) Handle(j *ccr.Job, commitSeq int64, createTable *rec
 	}
 	createTable.Sql = ccr.FilterDynamicPartitionStoragePolicyFromCreateTableSql(createTable.Sql)
 
+	if ccr.FeatureOverrideReplicationNum() && j.ReplicationNum > 0 {
+		createTable.Sql = ccr.ResetReplicationNumFromCreateTableSql(createTable.Sql, j.ReplicationNum)
+	}
+
 	if err := j.IDest.CreateTableOrView(createTable, j.Src.Database); err != nil {
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "Can not found function") {

--- a/pkg/ccr/handle/modify_property.go
+++ b/pkg/ccr/handle/modify_property.go
@@ -4,6 +4,7 @@ import (
 	"github.com/selectdb/ccr_syncer/pkg/ccr"
 	"github.com/selectdb/ccr_syncer/pkg/ccr/record"
 	festruct "github.com/selectdb/ccr_syncer/pkg/rpc/kitex_gen/frontendservice"
+	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -16,6 +17,13 @@ type ModifyTablePropertyHandle struct {
 }
 
 func (h *ModifyTablePropertyHandle) Handle(j *ccr.Job, commitSeq int64, modifyProperty *record.ModifyTableProperty) error {
+	if ccr.FeatureOverrideReplicationNum() && j.ReplicationNum > 0 {
+		if _, exists := modifyProperty.Properties["default.replication_allocation"]; exists {
+			delete(modifyProperty.Properties, "default.replication_allocation")
+			log.Debugf("delete default.replication_allocation from modify table property")
+		}
+	}
+
 	destTableName, err := j.GetDestNameBySrcId(modifyProperty.TableId)
 	if err != nil {
 		return err

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -27,6 +27,7 @@ import (
 	"math"
 	"math/rand"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -60,24 +61,25 @@ const (
 )
 
 var (
-	FeatureSchemaChangePartialSync      bool
-	featureCleanTableAndPartitions      bool
-	featureAtomicRestore                bool
-	FeatureCreateViewDropExists         bool
-	featureReplaceNotMatchedWithAlias   bool
-	featureFilterShadowIndexesUpsert    bool
-	featureReuseRunningBackupRestoreJob bool
-	featureCompressedSnapshot           bool
-	FeatureSkipRollupBinlogs            bool
-	featureTxnInsert                    bool
-	FeatureFilterStorageMedium          bool
-	featureRestoreReplaceDiffSchema     bool
-	featureIdempotentDDL                bool
-	featureSkipWaitingTxnPublish        bool
-	featureSkipCheckAsyncMvTable        bool
-	featurePipelineCommit               bool
-	featureSeperatedHandles             bool
-	featureEnableSnapshotCompress       bool
+	FeatureSchemaChangePartialSync        bool
+	featureCleanTableAndPartitions        bool
+	featureAtomicRestore                  bool
+	FeatureCreateViewDropExists           bool
+	featureReplaceNotMatchedWithAlias     bool
+	featureFilterShadowIndexesUpsert      bool
+	featureReuseRunningBackupRestoreJob   bool
+	featureCompressedSnapshot             bool
+	FeatureSkipRollupBinlogs              bool
+	featureTxnInsert                      bool
+	FeatureFilterStorageMedium            bool
+	featureRestoreReplaceDiffSchema       bool
+	featureIdempotentDDL                  bool
+	featureSkipWaitingTxnPublish          bool
+	featureSkipCheckAsyncMvTable          bool
+	featurePipelineCommit                 bool
+	featureSeperatedHandles               bool
+	featureEnableSnapshotCompress         bool
+	featureOverrideReplicationNumInternal bool
 
 	flagBinlogBatchSize int64
 
@@ -123,8 +125,15 @@ func init() {
 		"enable the seperated handles (the refactor)")
 	flag.BoolVar(&featureEnableSnapshotCompress, "feature_enable_snapshot_compress", true,
 		"enable snapshot compress")
+	flag.BoolVar(&featureOverrideReplicationNumInternal, "feature_override_replication_num", true,
+		"enable override replication_num for downstream cluster")
 
 	flag.Int64Var(&flagBinlogBatchSize, "binlog_batch_size", 16, "the max num of binlogs to get in a batch")
+}
+
+// FeatureOverrideReplicationNum returns whether the feature is enabled
+func FeatureOverrideReplicationNum() bool {
+	return featureOverrideReplicationNumInternal
 }
 
 type SyncType int
@@ -230,6 +239,9 @@ type Job struct {
 	pipelineCtx        *JobPipelineContext     `json:"-"`
 
 	lock sync.Mutex `json:"-"`
+
+	// Replication number policy: -1 means inherit from upstream (default), >0 means fixed replica num, 0 is invalid
+	ReplicationNum int `json:"replication_num,omitempty"`
 }
 
 type JobContext struct {
@@ -241,6 +253,8 @@ type JobContext struct {
 	AllowTableExists bool
 	ReuseBinlogLabel bool
 	Factory          *Factory
+	// Replication number policy: -1 means inherit from upstream (default), >0 means fixed replica num, 0 is invalid
+	ReplicationNum int
 }
 
 // new job
@@ -279,6 +293,24 @@ func NewJobFromService(name string, ctx context.Context) (*Job, error) {
 		stop:     make(chan struct{}),
 
 		concurrencyManager: rpc.NewConcurrencyManager(),
+	}
+
+	// set and validate replication number policy
+	job.ReplicationNum = jobContext.ReplicationNum
+	if job.ReplicationNum < -1 || job.ReplicationNum == 0 {
+		return nil, xerror.Errorf(xerror.Normal, "invalid replication_num: %d, must be -1 (inherit) or > 0 (fixed)", job.ReplicationNum)
+	}
+	if job.ReplicationNum > 0 {
+		backs, err := job.destMeta.GetBackends()
+		if err != nil {
+			return nil, xerror.Wrap(err, xerror.Normal, "get dest backends failed")
+		}
+		if len(backs) == 0 {
+			return nil, xerror.Errorf(xerror.Normal, "no available backends in dest cluster")
+		}
+		if job.ReplicationNum > len(backs) {
+			return nil, xerror.Errorf(xerror.Normal, "replication %d exceeds available BE %d", job.ReplicationNum, len(backs))
+		}
 	}
 
 	if err := job.valid(); err != nil {
@@ -395,6 +427,29 @@ func (j *Job) IsTableSyncWithAlias() bool {
 	return j.SyncType == TableSync && j.Src.Table != j.Dest.Table
 }
 
+// buildRestoreReplicationProperties decides restore properties according to replication number policy.
+// Mode:
+// - -1 (inherit, default): use reserve_replica=true to keep same replica number as source
+// - >0 (fixed): use replication_num = N, with strict capacity validation (fail by default)
+func (j *Job) buildRestoreReplicationProperties() (map[string]string, error) {
+	if !FeatureOverrideReplicationNum() {
+		// feature disabled, use default behavior (inherit)
+		return nil, nil
+	}
+
+	p := j.ReplicationNum
+	if p == -1 {
+		// inherit mode: let FE use default reserve_replica=true
+		return nil, nil
+	}
+
+	// fixed mode: p > 0
+	props := map[string]string{
+		"replication_num": strconv.Itoa(int(p)),
+	}
+	return props, nil
+}
+
 func (j *Job) isTableDropped(tableId int64) (bool, error) {
 	// Keep compatible with the old version, which doesn't have the table id in partial sync data.
 	if tableId == 0 {
@@ -410,6 +465,18 @@ func (j *Job) isTableDropped(tableId int64) (bool, error) {
 
 func (j *Job) getSourceThriftMeta(tableId int64) (*ThriftMeta, error) {
 	return j.factory.NewThriftMeta(&j.Src, j.factory, []int64{tableId})
+}
+
+// validateReplicaFail ensures the requested replica number does not exceed available BE nodes.
+func (j *Job) validateReplicaFail(num int) error {
+	backs, err := j.destMeta.GetBackends()
+	if err != nil {
+		return err
+	}
+	if num <= len(backs) {
+		return nil
+	}
+	return xerror.Errorf(xerror.Normal, "replication %d exceeds available BE %d", num, len(backs))
 }
 
 func (j *Job) addExtraInfo(jobInfo []byte) ([]byte, error) {
@@ -740,6 +807,14 @@ func (j *Job) partialSync() error {
 			Compress:        false,
 			ForceReplace:    isForceReplace,
 		}
+
+		// apply replication properties override if policy provided
+		if props, err := j.buildRestoreReplicationProperties(); err != nil {
+			return err
+		} else if props != nil {
+			restoreReq.PropertiesOverride = props
+		}
+
 		restoreResp, err := destRpc.RestoreSnapshot(dest, &restoreReq)
 		if err != nil {
 			return err
@@ -1168,6 +1243,12 @@ func (j *Job) fullSync() error {
 			CleanTables:     false,
 			AtomicRestore:   false,
 			Compress:        compress,
+		}
+		// apply replication properties override if policy provided
+		if props, err := j.buildRestoreReplicationProperties(); err != nil {
+			return err
+		} else if props != nil {
+			restoreReq.PropertiesOverride = props
 		}
 		if featureCleanTableAndPartitions {
 			// drop exists partitions, and drop tables if in db sync.
@@ -2121,6 +2202,10 @@ func (j *Job) handleCreateTable(binlog *festruct.TBinlog) error {
 	}
 	createTable.Sql = FilterDynamicPartitionStoragePolicyFromCreateTableSql(createTable.Sql)
 
+	if FeatureOverrideReplicationNum() && j.ReplicationNum > 0 {
+		createTable.Sql = ResetReplicationNumFromCreateTableSql(createTable.Sql, j.ReplicationNum)
+	}
+
 	if err = j.IDest.CreateTableOrView(createTable, j.Src.Database); err != nil {
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "Can not found function") {
@@ -2266,6 +2351,13 @@ func (j *Job) handleModifyProperty(binlog *festruct.TBinlog) error {
 
 	if j.IsBinlogCommitted(modifyProperty.TableId, binlog.GetCommitSeq()) {
 		return nil
+	}
+
+	if FeatureOverrideReplicationNum() && j.ReplicationNum > 0 {
+		if _, exists := modifyProperty.Properties["default.replication_allocation"]; exists {
+			delete(modifyProperty.Properties, "default.replication_allocation")
+			log.Debugf("delete default.replication_allocation from modify table property")
+		}
 	}
 
 	destTableName, err := j.GetDestNameBySrcId(modifyProperty.TableId)
@@ -3553,7 +3645,6 @@ func (j *Job) handleNonBarrierBinlog(binlog *festruct.TBinlog) error {
 		utils.RemoveJobFailpoint(j.Name, "handle_binlog_idempotent:before") // only work once
 		return xerror.Errorf(xerror.Normal, "fail to handle binlog by failpoint handle_binlog_idempotent:before")
 	}
-
 	var err error
 	if featureSeperatedHandles && IsJobHandleRegistered(binlogType) {
 		err = HandleBinlog(j, binlog)
@@ -4606,6 +4697,12 @@ func IsSessionVariableRequired(msg string) bool {
 func FilterStorageMediumFromCreateTableSql(createSql string) string {
 	pattern := `"storage_medium"\s*=\s*"[^"]*"(,\s*)?`
 	createSql = regexp.MustCompile(pattern).ReplaceAllString(createSql, "")
+	return FilterTailingCommaFromCreateTableSql(createSql)
+}
+
+func ResetReplicationNumFromCreateTableSql(createSql string, replicationNum int) string {
+	re := regexp.MustCompile(`("replication_allocation"\s*=\s*"[^:]*:\s*)\d+`)
+	createSql = re.ReplaceAllString(createSql, fmt.Sprintf("${1}%d", replicationNum))
 	return FilterTailingCommaFromCreateTableSql(createSql)
 }
 

--- a/pkg/rpc/fe.go
+++ b/pkg/rpc/fe.go
@@ -99,6 +99,9 @@ type RestoreSnapshotRequest struct {
 	CleanTables     bool
 	Compress        bool
 	ForceReplace    bool
+	// PropertiesOverride allows caller to pass-through properties for restore job,
+	// such as replication settings. If set, it will be preferred over defaults.
+	PropertiesOverride map[string]string
 }
 
 type IFeRpc interface {
@@ -848,8 +851,14 @@ func (rpc *singleFeClient) RestoreSnapshot(spec *base.Spec, restoreReq *RestoreS
 	client := rpc.client
 	repoName := "__keep_on_local__"
 	properties := make(map[string]string)
-	properties["reserve_replica"] = "true"
-
+	if restoreReq.PropertiesOverride != nil {
+		for k, v := range restoreReq.PropertiesOverride {
+			properties[k] = v
+		}
+	} else {
+		// default fallback for compatibility: keep downstream replicas consistent with upstream
+		properties["reserve_replica"] = "true"
+	}
 	// Support compressed snapshot
 	meta := restoreReq.SnapshotResult.GetMeta()
 	jobInfo := restoreReq.SnapshotResult.GetJobInfo()

--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -103,6 +103,8 @@ type CreateCcrRequest struct {
 	// For table sync, allow to create ccr job even if the target table already exists.
 	AllowTableExists bool `json:"allow_table_exists"`
 	ReuseBinlogLabel bool `json:"reuse_binlog_label"`
+	// replication_num: nil or -1 means inherit from upstream (default), >0 means fixed replica count, 0 is invalid
+	ReplicationNum *int `json:"replication_num,omitempty"`
 }
 
 // Stringer
@@ -132,6 +134,12 @@ func (s *HttpService) versionHandler(w http.ResponseWriter, r *http.Request) {
 func createCcr(request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobManager) error {
 	log.Infof("create ccr %s", request)
 
+	// Default to -1 (inherit mode) when replication_num is not specified
+	replicationNum := -1
+	if request.ReplicationNum != nil {
+		replicationNum = *request.ReplicationNum
+	}
+
 	ctx := &ccr.JobContext{
 		Context:          context.Background(),
 		Src:              request.Src,
@@ -141,6 +149,7 @@ func createCcr(request *CreateCcrRequest, db storage.DB, jobManager *ccr.JobMana
 		ReuseBinlogLabel: request.ReuseBinlogLabel,
 		Db:               db,
 		Factory:          jobManager.GetFactory(),
+		ReplicationNum:   replicationNum,
 	}
 	job, err := ccr.NewJobFromService(request.Name, ctx)
 	if err != nil {

--- a/regression-test/suites/db_sync/prop/replication_num/test_ds_replication_num_fixed.groovy
+++ b/regression-test/suites/db_sync/prop/replication_num/test_ds_replication_num_fixed.groovy
@@ -1,0 +1,124 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('test_ds_replication_num_fixed') {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", 'helper.groovy'))
+
+    def suffix = helper.randomSuffix()
+    def tableName1 = 'tbl1_' + suffix
+    def tableName2 = 'tbl2_' + suffix
+    def dbName = context.dbName
+    
+    helper.enableDbBinlog()
+    
+    // Create first table with replication_num = 3 on source cluster
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName1}
+        (
+            `id` INT,
+            `name` VARCHAR(128)
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 3",
+            "binlog.enable" = "true"
+        )
+    """
+    
+    sql """ INSERT INTO ${tableName1} VALUES (1, 'test1') """
+    
+    helper.ccrJobDelete()
+    
+    // Create DB Sync CCR job with replication_num = 1
+    helper.ccrJobCreateWithReplicationNum("", 1)
+    
+    // Wait for first table to sync
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName1}", 60))
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName1}\"", 
+        { res -> res.size() == 1 }, 60, 'target'))
+    
+    // Verify data sync
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", 1, 60))
+    
+    // Verify first table's replication_num on target (should be 1, not 3)
+    def targetSql1 = target_sql "SHOW CREATE TABLE ${tableName1}"
+    logger.info("Target table1 DDL: ${targetSql1}")
+    assertTrue(targetSql1.toString().contains("tag.location.default: 1"), 
+        "Target table should have replication_num = 1")
+    
+    // Create second table with different replication_num on source
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName2}
+        (
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 2",
+            "binlog.enable" = "true"
+        )
+    """
+    
+    sql """ INSERT INTO ${tableName2} VALUES (100, 200) """
+    
+    // Wait for second table to sync
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName2}\"", 
+        { res -> res.size() == 1 }, 60, 'target'))
+    
+    // Verify second table's data
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName2}", 1, 60))
+    
+    // Verify second table's replication_num on target (should also be 1, not 2)
+    def targetSql2 = target_sql "SHOW CREATE TABLE ${tableName2}"
+    logger.info("Target table2 DDL: ${targetSql2}")
+    assertTrue(targetSql2.toString().contains("tag.location.default: 1"), 
+        "Target table2 should have replication_num = 1")
+    
+    // Test ALTER TABLE PROPERTIES - should be ignored
+    sql """
+        ALTER TABLE ${tableName1} 
+        SET ("default.replication_allocation" = "tag.location.default: 3")
+    """
+    
+    // Wait for binlog sync
+    Thread.sleep(5000)
+    
+    // Verify target table's replication_num remains 1
+    def afterAlterSql = target_sql "SHOW CREATE TABLE ${tableName1}"
+    logger.info("After ALTER target table1 DDL: ${afterAlterSql}")
+    assertTrue(afterAlterSql.toString().contains("tag.location.default: 1"), 
+        "Target table should still have replication_num = 1 after ALTER")
+    
+    // Test DML on both tables
+    sql """ INSERT INTO ${tableName1} VALUES (2, 'test2') """
+    sql """ INSERT INTO ${tableName2} VALUES (101, 201) """
+    
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", 2, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName2}", 2, 60))
+    
+    logger.info("Test passed: DB sync with replication_num override works correctly")
+    
+    // Cleanup: delete CCR job
+    helper.ccrJobDelete()
+}
+

--- a/regression-test/suites/db_sync/prop/replication_num/test_ds_replication_num_inherit.groovy
+++ b/regression-test/suites/db_sync/prop/replication_num/test_ds_replication_num_inherit.groovy
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('test_ds_replication_num_inherit') {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", 'helper.groovy'))
+
+    def suffix = helper.randomSuffix()
+    def tableName1 = 'tbl1_' + suffix
+    def tableName2 = 'tbl2_' + suffix
+    def dbName = context.dbName
+    
+    helper.enableDbBinlog()
+    
+    // Create first table with replication_num = 1 on source cluster
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName1}
+        (
+            `id` INT,
+            `name` VARCHAR(128)
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    
+    sql """ INSERT INTO ${tableName1} VALUES (1, 'test1') """
+    
+    helper.ccrJobDelete()
+    
+    // Create DB Sync CCR job with replication_num = -1 (inherit from source)
+    helper.ccrJobCreateWithReplicationNum("", -1)
+    
+    // Wait for first table to sync
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName1}", 60))
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName1}\"", 
+        { res -> res.size() == 1 }, 60, 'target'))
+    
+    // Verify data sync
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", 1, 60))
+    
+    // Verify first table's replication_num on target (should inherit from source: 1)
+    def targetSql1 = target_sql "SHOW CREATE TABLE ${tableName1}"
+    logger.info("Target table1 DDL: ${targetSql1}")
+    assertTrue(targetSql1.toString().contains("tag.location.default: 1"), 
+        "Target table should inherit replication_num = 1 from source")
+    
+    // Create second table with different replication_num on source
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName2}
+        (
+            `id` INT,
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 2",
+            "binlog.enable" = "true"
+        )
+    """
+    
+    sql """ INSERT INTO ${tableName2} VALUES (100, 200) """
+    
+    // Wait for second table to sync
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName2}\"", 
+        { res -> res.size() == 1 }, 60, 'target'))
+    
+    // Verify second table's data
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName2}", 1, 60))
+    
+    // Verify second table's replication_num on target (should inherit from source: 2, not 1)
+    def targetSql2 = target_sql "SHOW CREATE TABLE ${tableName2}"
+    logger.info("Target table2 DDL: ${targetSql2}")
+    assertTrue(targetSql2.toString().contains("tag.location.default: 2"), 
+        "Target table2 should inherit replication_num = 2 from source")
+    
+    // Test ALTER TABLE PROPERTIES - should sync to target when in inherit mode
+    // Change table1's replication_num from 1 to 3 to verify inheritance behavior
+    sql """
+        ALTER TABLE ${tableName1} 
+        SET ("default.replication_allocation" = "tag.location.default: 3")
+    """
+    
+    // Wait for binlog sync
+    Thread.sleep(5000)
+    
+    // Verify target table's replication_num follows the change from 1 to 3
+    def afterAlterSql = target_sql "SHOW CREATE TABLE ${tableName1}"
+    logger.info("After ALTER target table1 DDL: ${afterAlterSql}")
+    assertTrue(afterAlterSql.toString().contains("tag.location.default: 3"), 
+        "Target table should follow source's replication_num change (1 -> 3) in inherit mode")
+    
+    // Test DML on both tables
+    sql """ INSERT INTO ${tableName1} VALUES (2, 'test2') """
+    sql """ INSERT INTO ${tableName2} VALUES (101, 201) """
+    
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName1}", 2, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName2}", 2, 60))
+    
+    logger.info("Test passed: DB sync with replication_num inherit mode works correctly")
+    
+    // Cleanup: delete CCR job
+    helper.ccrJobDelete()
+}
+
+

--- a/regression-test/suites/db_sync/prop/replication_num/test_ds_replication_num_invalid.groovy
+++ b/regression-test/suites/db_sync/prop/replication_num/test_ds_replication_num_invalid.groovy
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('test_ds_replication_num_invalid') {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", 'helper.groovy'))
+
+    def suffix = helper.randomSuffix()
+    def tableName = 'tbl_' + suffix
+    def dbName = context.dbName
+    
+    helper.enableDbBinlog()
+    
+    // Create table on source cluster
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `id` INT,
+            `name` VARCHAR(128)
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    
+    sql """ INSERT INTO ${tableName} VALUES (1, 'test1') """
+    
+    helper.ccrJobDelete()
+    
+    // Test invalid value: replication_num = 0 (should fail)
+    logger.info("Testing invalid replication_num = 0 for DB Sync")
+    def bodyJson = helper.get_ccr_body ""
+    def jsonSlurper = new groovy.json.JsonSlurper()
+    def object = jsonSlurper.parseText "${bodyJson}"
+    object['replication_num'] = 0
+    
+    bodyJson = new groovy.json.JsonBuilder(object).toString()
+    
+    def failed = false
+    try {
+        httpTest {
+            uri "/create_ccr"
+            endpoint helper.syncerAddress
+            body "${bodyJson}"
+            op "post"
+            check { code, body ->
+                def value = jsonSlurper.parseText "${body}"
+                if (!value.success) {
+                    // Expected to fail
+                    logger.info("Expected failure for replication_num=0: ${value.error_msg}")
+                    assertTrue(value.error_msg.contains("invalid") || 
+                               value.error_msg.contains("must be -1") ||
+                               value.error_msg.contains("or > 0"),
+                        "Error message should indicate invalid replication_num")
+                    failed = true
+                } else {
+                    throw new Exception("replication_num=0 should fail but succeeded")
+                }
+            }
+        }
+    } catch (Exception e) {
+        logger.info("Caught expected exception: ${e.message}")
+        failed = true
+    }
+    
+    assertTrue(failed, "replication_num=0 should be rejected")
+    
+    // Test invalid value: replication_num = -2 (should fail)
+    logger.info("Testing invalid replication_num = -2 for DB Sync")
+    object['replication_num'] = -2
+    bodyJson = new groovy.json.JsonBuilder(object).toString()
+    
+    failed = false
+    try {
+        httpTest {
+            uri "/create_ccr"
+            endpoint helper.syncerAddress
+            body "${bodyJson}"
+            op "post"
+            check { code, body ->
+                def value = jsonSlurper.parseText "${body}"
+                if (!value.success) {
+                    logger.info("Expected failure for replication_num=-2: ${value.error_msg}")
+                    assertTrue(value.error_msg.contains("invalid") || 
+                               value.error_msg.contains("must be -1") ||
+                               value.error_msg.contains("or > 0"),
+                        "Error message should indicate invalid replication_num")
+                    failed = true
+                } else {
+                    throw new Exception("replication_num=-2 should fail but succeeded")
+                }
+            }
+        }
+    } catch (Exception e) {
+        logger.info("Caught expected exception: ${e.message}")
+        failed = true
+    }
+    
+    assertTrue(failed, "replication_num=-2 should be rejected")
+    
+    // Test valid value: replication_num = 1 (should succeed)
+    logger.info("Testing valid replication_num = 1 for DB Sync")
+    helper.ccrJobCreateWithReplicationNum("", 1)
+    
+    // Verify job created successfully and table synced
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 60))
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName}\"", 
+        { res -> res.size() == 1 }, 60, 'target'))
+    
+    // Verify data sync
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", 1, 60))
+    
+    // Verify replication_num on target
+    def targetSql = target_sql "SHOW CREATE TABLE ${tableName}"
+    logger.info("Target table DDL: ${targetSql}")
+    assertTrue(targetSql.toString().contains("tag.location.default: 1"), 
+        "Target table should have replication_num = 1")
+    
+    logger.info("Test passed: invalid replication_num values are correctly rejected for DB Sync")
+    
+    // Cleanup: delete CCR job
+    helper.ccrJobDelete()
+}
+
+

--- a/regression-test/suites/table_sync/prop/replication_num/test_ts_replication_num_fixed.groovy
+++ b/regression-test/suites/table_sync/prop/replication_num/test_ts_replication_num_fixed.groovy
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('test_ts_replication_num_fixed') {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", 'helper.groovy'))
+
+    def suffix = helper.randomSuffix()
+    def tableName = 'tbl_' + suffix
+    
+    helper.enableDbBinlog()
+    
+    // Create table with replication_num = 3 on source cluster
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `id` INT,
+            `name` VARCHAR(128),
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 3",
+            "binlog.enable" = "true"
+        )
+    """
+    
+    // Insert some initial data
+    sql """ INSERT INTO ${tableName} VALUES (1, 'test1', 100) """
+    sql """ INSERT INTO ${tableName} VALUES (2, 'test2', 200) """
+    
+    helper.ccrJobDelete(tableName)
+    
+    // Create CCR job with replication_num = 1 (override source's 3 replicas)
+    helper.ccrJobCreateWithReplicationNum(tableName, 1)
+    
+    // Wait for restore to finish
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 60))
+    
+    // Check table exists on target
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName}\"", 
+        { res -> res.size() == 1 }, 60, 'target'))
+    
+    // Verify data sync
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", 2, 60))
+    
+    // Get and verify replication_num on target cluster
+    def targetSql = target_sql "SHOW CREATE TABLE ${tableName}"
+    logger.info("Target table DDL: ${targetSql}")
+    assertTrue(targetSql.toString().contains("tag.location.default: 1"), 
+        "Target table should have replication_num = 1")
+    
+    // Note: Table Sync only syncs the specified table, not new tables created later
+    // For new table sync testing, see DB Sync tests instead
+    
+    // Test ALTER TABLE PROPERTIES - should be ignored when replication_num is set
+    sql """
+        ALTER TABLE ${tableName} 
+        SET ("default.replication_allocation" = "tag.location.default: 2")
+    """
+    
+    // Wait a bit for binlog sync
+    Thread.sleep(5000)
+    
+    // Verify target table's replication_num remains 1 (not changed to 2)
+    def afterAlterSql = target_sql "SHOW CREATE TABLE ${tableName}"
+    logger.info("After ALTER target table DDL: ${afterAlterSql}")
+    assertTrue(afterAlterSql.toString().contains("tag.location.default: 1"), 
+        "Target table should still have replication_num = 1 after ALTER")
+    
+    // Continue to test DML operations
+    sql """ INSERT INTO ${tableName} VALUES (3, 'test3', 300) """
+    sql """ UPDATE ${tableName} SET value = 150 WHERE id = 1 """
+    sql """ DELETE FROM ${tableName} WHERE id = 2 """
+    
+    // Verify DML operations synced correctly
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName} WHERE id = 1 AND value = 150", 
+        1, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName} WHERE id = 3", 1, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName} WHERE id = 2", 0, 60))
+    
+    logger.info("Test passed: replication_num override works correctly")
+    
+    // Cleanup: delete CCR job
+    helper.ccrJobDelete(tableName)
+}
+

--- a/regression-test/suites/table_sync/prop/replication_num/test_ts_replication_num_inherit.groovy
+++ b/regression-test/suites/table_sync/prop/replication_num/test_ts_replication_num_inherit.groovy
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('test_ts_replication_num_inherit') {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", 'helper.groovy'))
+
+    def suffix = helper.randomSuffix()
+    def tableName = 'tbl_' + suffix
+    
+    helper.enableDbBinlog()
+    
+    // Create table with replication_num = 1 on source cluster
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `id` INT,
+            `name` VARCHAR(128),
+            `value` INT
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    
+    // Insert some initial data
+    sql """ INSERT INTO ${tableName} VALUES (1, 'test1', 100) """
+    sql """ INSERT INTO ${tableName} VALUES (2, 'test2', 200) """
+    
+    helper.ccrJobDelete(tableName)
+    
+    // Create CCR job with replication_num = -1 (inherit from source, default behavior)
+    helper.ccrJobCreateWithReplicationNum(tableName, -1)
+    
+    // Wait for restore to finish
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 60))
+    
+    // Check table exists on target
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName}\"", 
+        { res -> res.size() == 1 }, 60, 'target'))
+    
+    // Verify data sync
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName}", 2, 60))
+    
+    // Get and verify replication_num on target cluster (should inherit from source: 1)
+    def targetSql = target_sql "SHOW CREATE TABLE ${tableName}"
+    logger.info("Target table DDL: ${targetSql}")
+    assertTrue(targetSql.toString().contains("tag.location.default: 1"), 
+        "Target table should inherit replication_num = 1 from source")
+    
+    // Note: Table Sync only syncs the specified table, not new tables created later
+    // For new table sync testing, see DB Sync tests instead
+    
+    // Test ALTER TABLE PROPERTIES - should sync to target when in inherit mode
+    // Change replication_num from 1 to 2 to verify inheritance behavior
+    sql """
+        ALTER TABLE ${tableName} 
+        SET ("default.replication_allocation" = "tag.location.default: 2")
+    """
+    
+    // Wait for binlog sync
+    Thread.sleep(5000)
+    
+    // Verify target table's replication_num follows the change from 1 to 2
+    def afterAlterSql = target_sql "SHOW CREATE TABLE ${tableName}"
+    logger.info("After ALTER target table DDL: ${afterAlterSql}")
+    assertTrue(afterAlterSql.toString().contains("tag.location.default: 2"), 
+        "Target table should follow source's replication_num change (1 -> 2) in inherit mode")
+    
+    // Continue to test DML operations
+    sql """ INSERT INTO ${tableName} VALUES (3, 'test3', 300) """
+    sql """ UPDATE ${tableName} SET value = 150 WHERE id = 1 """
+    
+    // Verify DML operations synced correctly
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName} WHERE id = 1 AND value = 150", 
+        1, 60))
+    assertTrue(helper.checkSelectTimesOf("SELECT * FROM ${tableName} WHERE id = 3", 1, 60))
+    
+    logger.info("Test passed: replication_num inherit mode works correctly")
+    
+    // Cleanup: delete CCR job
+    helper.ccrJobDelete(tableName)
+}
+

--- a/regression-test/suites/table_sync/prop/replication_num/test_ts_replication_num_invalid.groovy
+++ b/regression-test/suites/table_sync/prop/replication_num/test_ts_replication_num_invalid.groovy
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('test_ts_replication_num_invalid') {
+    def helper = new GroovyShell(new Binding(['suite': delegate]))
+            .evaluate(new File("${context.config.suitePath}/../common", 'helper.groovy'))
+
+    def suffix = helper.randomSuffix()
+    def tableName = 'tbl_' + suffix
+    
+    helper.enableDbBinlog()
+    
+    // Create table on source cluster
+    sql """
+        CREATE TABLE if NOT EXISTS ${tableName}
+        (
+            `id` INT,
+            `name` VARCHAR(128)
+        )
+        ENGINE=OLAP
+        UNIQUE KEY(`id`)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "binlog.enable" = "true"
+        )
+    """
+    
+    helper.ccrJobDelete(tableName)
+    
+    // Test invalid value: replication_num = 0 (should fail)
+    logger.info("Testing invalid replication_num = 0")
+    def bodyJson = helper.get_ccr_body "${tableName}"
+    def jsonSlurper = new groovy.json.JsonSlurper()
+    def object = jsonSlurper.parseText "${bodyJson}"
+    object['replication_num'] = 0
+    
+    bodyJson = new groovy.json.JsonBuilder(object).toString()
+    
+    def failed = false
+    try {
+        httpTest {
+            uri "/create_ccr"
+            endpoint helper.syncerAddress
+            body "${bodyJson}"
+            op "post"
+            check { code, body ->
+                def value = jsonSlurper.parseText "${body}"
+                if (!value.success) {
+                    // Expected to fail
+                    logger.info("Expected failure for replication_num=0: ${value.error_msg}")
+                    assertTrue(value.error_msg.contains("invalid") || 
+                               value.error_msg.contains("must be -1") ||
+                               value.error_msg.contains("or > 0"),
+                        "Error message should indicate invalid replication_num")
+                    failed = true
+                } else {
+                    throw new Exception("replication_num=0 should fail but succeeded")
+                }
+            }
+        }
+    } catch (Exception e) {
+        logger.info("Caught expected exception: ${e.message}")
+        failed = true
+    }
+    
+    assertTrue(failed, "replication_num=0 should be rejected")
+    
+    // Test invalid value: replication_num = -2 (should fail)
+    logger.info("Testing invalid replication_num = -2")
+    object['replication_num'] = -2
+    bodyJson = new groovy.json.JsonBuilder(object).toString()
+    
+    failed = false
+    try {
+        httpTest {
+            uri "/create_ccr"
+            endpoint helper.syncerAddress
+            body "${bodyJson}"
+            op "post"
+            check { code, body ->
+                def value = jsonSlurper.parseText "${body}"
+                if (!value.success) {
+                    logger.info("Expected failure for replication_num=-2: ${value.error_msg}")
+                    assertTrue(value.error_msg.contains("invalid") || 
+                               value.error_msg.contains("must be -1") ||
+                               value.error_msg.contains("or > 0"),
+                        "Error message should indicate invalid replication_num")
+                    failed = true
+                } else {
+                    throw new Exception("replication_num=-2 should fail but succeeded")
+                }
+            }
+        }
+    } catch (Exception e) {
+        logger.info("Caught expected exception: ${e.message}")
+        failed = true
+    }
+    
+    assertTrue(failed, "replication_num=-2 should be rejected")
+    
+    // Test valid value: replication_num = 1 (should succeed)
+    logger.info("Testing valid replication_num = 1")
+    helper.ccrJobCreateWithReplicationNum(tableName, 1)
+    
+    // Verify job created successfully
+    assertTrue(helper.checkRestoreFinishTimesOf("${tableName}", 60))
+    assertTrue(helper.checkShowTimesOf("SHOW TABLES LIKE \"${tableName}\"", 
+        { res -> res.size() == 1 }, 60, 'target'))
+    
+    logger.info("Test passed: invalid replication_num values are correctly rejected")
+    
+    // Cleanup: delete CCR job
+    helper.ccrJobDelete(tableName)
+}
+


### PR DESCRIPTION
## 背景

备份集群通常出于成本考虑，副本数会比源集群要少。例如生产环境使用 3 副本保证高可用，而备份环境只需 1-2 副本即可满足灾备需求。当前 CCR 默认继承上游副本数设置，导致备份集群资源浪费。

## 改动说明

新增 `replication_num` 参数支持自定义下游集群副本数策略。

## 实现方式

- 在创建 CCR 任务 API 中新增 `replication_num` 字段
- 支持两种模式：
  - 不传或 `-1`：继承上游副本数（默认行为，使用 `reserve_replica=true`）
  - `>0`：强制使用固定副本数（如 `1` 表示单副本）
  - `0`：无效值，创建时报错
- 副本数策略在以下场景生效：
  - 全量/增量快照恢复
  - CREATE TABLE binlog 同步（重写 SQL 中的 `replication_allocation`）
  - ALTER TABLE PROPERTIES 同步（固定模式下忽略上游的副本数修改）
- 新增 feature flag `feature_override_replication_num`（默认开启）控制该功能
- 校验固定副本数不超过下游集群可用 BE 节点数

## 使用示例

```bash
# 继承模式（默认或replication_num : -1）
curl -X POST http://localhost:9190/create_ccr -d '{
  "name": "job1",
  "src": {...},
  "dest": {...}
}'

# 固定模式（备份集群使用 1 副本降低成本）
curl -X POST http://localhost:9190/create_ccr -d '{
  "name": "job2",
  "src": {...},
  "dest": {...},
  "replication_num": 1
}'
```

## NOTE
1. `AddPartition`：BInlog-data中没有包含副本数信息，没有改动，使用默认副本数。
2. `ModifyPartition`: 暂时未支持。