### PR TITLE
fix: Remove BE caching mechanism and simplify replication number validation

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -301,15 +301,8 @@ func NewJobFromService(name string, ctx context.Context) (*Job, error) {
 		return nil, xerror.Errorf(xerror.Normal, "invalid replication_num: %d, must be -1 (inherit) or > 0 (fixed)", job.ReplicationNum)
 	}
 	if job.ReplicationNum > 0 {
-		backs, err := job.destMeta.GetBackends()
-		if err != nil {
-			return nil, xerror.Wrap(err, xerror.Normal, "get dest backends failed")
-		}
-		if len(backs) == 0 {
-			return nil, xerror.Errorf(xerror.Normal, "no available backends in dest cluster")
-		}
-		if job.ReplicationNum > len(backs) {
-			return nil, xerror.Errorf(xerror.Normal, "replication %d exceeds available BE %d", job.ReplicationNum, len(backs))
+		if err := job.validateReplicaFail(job.ReplicationNum); err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -4484,6 +4484,12 @@ func (j *Job) SkipBinlog(params SkipBinlogParams) error {
 	return nil
 }
 
+// InvalidateBackendsCache invalidates the backends cache for both src and dest clusters.
+func (j *Job) InvalidateBackendsCache() {
+	j.srcMeta.InvalidateBackendsCache()
+	j.destMeta.InvalidateBackendsCache()
+}
+
 func (j *Job) GetSpecifiedBinlog(commitSeq int64) (*festruct.TBinlog, error) {
 	if binlog, ok := j.Extra.CachedBinlogs[commitSeq]; ok {
 		return binlog, nil

--- a/pkg/ccr/job_manager.go
+++ b/pkg/ccr/job_manager.go
@@ -277,3 +277,22 @@ func (jm *JobManager) SkipBinlog(jobName string, params SkipBinlogParams) error 
 		return xerror.Errorf(xerror.Normal, "job not exist: %s", jobName)
 	}
 }
+
+// InvalidateBackendsCache invalidates backends cache. If jobName is empty, invalidates all jobs.
+func (jm *JobManager) InvalidateBackendsCache(jobName string) (int, error) {
+	jm.lock.RLock()
+	defer jm.lock.RUnlock()
+
+	if jobName != "" {
+		if job, ok := jm.jobs[jobName]; ok {
+			job.InvalidateBackendsCache()
+			return 1, nil
+		}
+		return 0, xerror.Errorf(xerror.Normal, "job not exist: %s", jobName)
+	}
+
+	for _, job := range jm.jobs {
+		job.InvalidateBackendsCache()
+	}
+	return len(jm.jobs), nil
+}

--- a/pkg/ccr/meta.go
+++ b/pkg/ccr/meta.go
@@ -615,42 +615,36 @@ func (m *Meta) GetFrontends() ([]*base.Frontend, error) {
 }
 
 func (m *Meta) GetBackends() ([]*base.Backend, error) {
-	if len(m.Backends) > 0 {
-		backends := make([]*base.Backend, 0, len(m.Backends))
-		for _, backend := range m.Backends {
-			backend := *backend // copy
-			backends = append(backends, &backend)
-		}
-		if len(m.HostMapping) != 0 {
-			for _, backend := range backends {
-				if host, ok := m.HostMapping[backend.Host]; ok {
-					backend.Host = host
-				} else {
-					return nil, xerror.Errorf(xerror.Normal,
-						"the public ip of host %s is not found, consider adding it via HTTP API /add_host_mapping", backend.Host)
-				}
-			}
-		}
-		return backends, nil
-	}
-
+	// Always fetch latest backend information from FE
 	if err := m.UpdateBackends(); err != nil {
 		return nil, err
 	}
 
-	return m.GetBackends()
+	backends := make([]*base.Backend, 0, len(m.Backends))
+	for _, backend := range m.Backends {
+		backend := *backend // copy
+		backends = append(backends, &backend)
+	}
+	if len(m.HostMapping) != 0 {
+		for _, backend := range backends {
+			if host, ok := m.HostMapping[backend.Host]; ok {
+				backend.Host = host
+			} else {
+				return nil, xerror.Errorf(xerror.Normal,
+					"the public ip of host %s is not found, consider adding it via HTTP API /add_host_mapping", backend.Host)
+			}
+		}
+	}
+	return backends, nil
 }
 
 func (m *Meta) GetBackendMap() (map[int64]*base.Backend, error) {
-	if len(m.Backends) > 0 {
-		return m.Backends, nil
-	}
-
+	// Always fetch latest backend information from FE
 	if err := m.UpdateBackends(); err != nil {
 		return nil, err
 	}
 
-	return m.GetBackendMap()
+	return m.Backends, nil
 }
 
 func (m *Meta) GetBackendId(host string, portStr string) (int64, error) {

--- a/pkg/ccr/meta.go
+++ b/pkg/ccr/meta.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/selectdb/ccr_syncer/pkg/ccr/base"
 	"github.com/selectdb/ccr_syncer/pkg/rpc"
@@ -31,6 +33,12 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/tidwall/btree"
+)
+
+const (
+	// DefaultBackendsCacheTTL is the default time-to-live for backends cache.
+	// After this duration, the cache will be considered stale and will be refreshed.
+	DefaultBackendsCacheTTL = 60 * time.Second
 )
 
 const (
@@ -50,8 +58,8 @@ func fmtHostPort(host string, port uint16) string {
 	return fmt.Sprintf("%s:%d", host, port)
 }
 
-// All op is not concurrent safety
-// Meta
+// Meta stores cluster metadata with caching support.
+// All operations are not concurrent safe except for backend cache methods.
 type Meta struct {
 	*base.Spec
 	DatabaseMeta
@@ -60,6 +68,11 @@ type Meta struct {
 	DatabaseName2IdMap    map[string]int64
 	TableName2IdMap       map[string]int64
 	BackendHostPort2IdMap map[string]int64
+
+	// backend cache fields (protected by backendsLock)
+	backendsLock       sync.RWMutex
+	backendsLastUpdate time.Time
+	backendsInvalid    bool
 }
 
 func NewMeta(spec *base.Spec) *Meta {
@@ -541,6 +554,16 @@ func (m *Meta) UpdateBackends() error {
 		return xerror.Wrap(err, xerror.Normal, query)
 	}
 
+	// Update cache with lock
+	m.backendsLock.Lock()
+	defer m.backendsLock.Unlock()
+
+	oldCount := len(m.Backends)
+
+	// Clear and rebuild backends map
+	m.Backends = make(map[int64]*base.Backend)
+	m.BackendHostPort2IdMap = make(map[string]int64)
+
 	for _, backend := range backends {
 		m.Backends[backend.Id] = backend
 
@@ -548,7 +571,41 @@ func (m *Meta) UpdateBackends() error {
 		m.BackendHostPort2IdMap[hostPort] = backend.Id
 	}
 
+	// update cache metadata
+	m.backendsLastUpdate = time.Now()
+	m.backendsInvalid = false
+
+	newCount := len(m.Backends)
+	if oldCount > 0 && oldCount != newCount {
+		log.Infof("backend count changed: %d -> %d", oldCount, newCount)
+	}
+	log.Debugf("backends cache updated, count: %d, ttl: %v", newCount, DefaultBackendsCacheTTL)
+
 	return nil
+}
+
+// isBackendsCacheValid checks if backend cache is still valid (not expired and not invalidated).
+func (m *Meta) isBackendsCacheValid() bool {
+	m.backendsLock.RLock()
+	defer m.backendsLock.RUnlock()
+
+	hasData := len(m.Backends) > 0
+	notInvalid := !m.backendsInvalid
+	notExpired := time.Since(m.backendsLastUpdate) < DefaultBackendsCacheTTL
+	valid := hasData && notInvalid && notExpired
+
+	log.Tracef("backends cache check: hasData=%v, notInvalid=%v, notExpired=%v, valid=%v",
+		hasData, notInvalid, notExpired, valid)
+	return valid
+}
+
+// InvalidateBackendsCache marks the backends cache as invalid.
+// Call this when cluster is scaled (add/remove backends).
+func (m *Meta) InvalidateBackendsCache() {
+	m.backendsLock.Lock()
+	defer m.backendsLock.Unlock()
+	m.backendsInvalid = true
+	log.Debugf("backends cache invalidated, will refresh on next access")
 }
 
 func (m *Meta) GetFrontends() ([]*base.Frontend, error) {
@@ -615,10 +672,17 @@ func (m *Meta) GetFrontends() ([]*base.Frontend, error) {
 }
 
 func (m *Meta) GetBackends() ([]*base.Backend, error) {
-	// Always fetch latest backend information from FE
-	if err := m.UpdateBackends(); err != nil {
-		return nil, err
+	if !m.isBackendsCacheValid() {
+		log.Debugf("backends cache miss, refreshing from FE")
+		if err := m.UpdateBackends(); err != nil {
+			return nil, err
+		}
+	} else {
+		log.Tracef("backends cache hit, using cached data")
 	}
+
+	m.backendsLock.RLock()
+	defer m.backendsLock.RUnlock()
 
 	backends := make([]*base.Backend, 0, len(m.Backends))
 	for _, backend := range m.Backends {
@@ -639,11 +703,17 @@ func (m *Meta) GetBackends() ([]*base.Backend, error) {
 }
 
 func (m *Meta) GetBackendMap() (map[int64]*base.Backend, error) {
-	// Always fetch latest backend information from FE
-	if err := m.UpdateBackends(); err != nil {
-		return nil, err
+	if !m.isBackendsCacheValid() {
+		log.Debugf("backends cache miss, refreshing from FE")
+		if err := m.UpdateBackends(); err != nil {
+			return nil, err
+		}
+	} else {
+		log.Tracef("backends cache hit, using cached data")
 	}
 
+	m.backendsLock.RLock()
+	defer m.backendsLock.RUnlock()
 	return m.Backends, nil
 }
 

--- a/pkg/ccr/metaer.go
+++ b/pkg/ccr/metaer.go
@@ -164,6 +164,7 @@ type Metaer interface {
 	UpdateBackends() error
 	GetBackends() ([]*base.Backend, error)
 	GetBackendId(host, portStr string) (int64, error)
+	InvalidateBackendsCache() // invalidate cache when cluster scaled
 
 	UpdateIndexes(tableId, partitionId int64) error
 	ShowIndexes(tableName string) ([]*IndexDesc, error)

--- a/pkg/ccr/metaer_mock.go
+++ b/pkg/ccr/metaer_mock.go
@@ -327,6 +327,18 @@ func (mr *MockMetaerMockRecorder) GetBackends() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackends", reflect.TypeOf((*MockMetaer)(nil).GetBackends))
 }
 
+// InvalidateBackendsCache mocks base method.
+func (m *MockMetaer) InvalidateBackendsCache() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InvalidateBackendsCache")
+}
+
+// InvalidateBackendsCache indicates an expected call of InvalidateBackendsCache.
+func (mr *MockMetaerMockRecorder) InvalidateBackendsCache() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateBackendsCache", reflect.TypeOf((*MockMetaer)(nil).InvalidateBackendsCache))
+}
+
 // GetDbId mocks base method.
 func (m *MockMetaer) GetDbId() (int64, error) {
 	m.ctrl.T.Helper()

--- a/pkg/service/http_service.go
+++ b/pkg/service/http_service.go
@@ -1121,6 +1121,35 @@ func (s *HttpService) failpointHandler(w http.ResponseWriter, r *http.Request) {
 	result = newSuccessResult()
 }
 
+// invalidateBackendsCacheHandler invalidates backends cache for scaling scenarios.
+// Request body is optional:
+//   - empty or {"name": ""} -> invalidate all jobs
+//   - {"name": "job1"}      -> invalidate specific job only
+func (s *HttpService) invalidateBackendsCacheHandler(w http.ResponseWriter, r *http.Request) {
+	log.Info("invalidate backends cache")
+
+	type result struct {
+		*defaultResult
+		InvalidatedCount int `json:"invalidated_count"`
+	}
+	var res *result
+	defer func() { writeJson(w, res) }()
+
+	var request CcrCommonRequest
+	// ignore decode error for empty body, treat as invalidate all
+	_ = json.NewDecoder(r.Body).Decode(&request)
+
+	count, err := s.jobManager.InvalidateBackendsCache(request.Name)
+	if err != nil {
+		log.Warnf("invalidate backends cache failed: %+v", err)
+		res = &result{defaultResult: newErrorResult(err.Error())}
+		return
+	}
+
+	log.Infof("invalidated backends cache, job: %q, count: %d", request.Name, count)
+	res = &result{defaultResult: newSuccessResult(), InvalidatedCount: count}
+}
+
 func (s *HttpService) RegisterHandlers() {
 	s.mux.HandleFunc("/version", s.versionHandler)
 	s.mux.HandleFunc("/create_ccr", s.createHandler)
@@ -1138,6 +1167,7 @@ func (s *HttpService) RegisterHandlers() {
 	s.mux.HandleFunc("/update_host_mapping", s.updateHostMappingHandler)
 	s.mux.HandleFunc("/job_skip_binlog", s.skipBinlogHandler)
 	s.mux.HandleFunc("/failpoint", s.failpointHandler)
+	s.mux.HandleFunc("/invalidate_backends_cache", s.invalidateBackendsCacheHandler)
 	s.mux.Handle("/metrics", xmetrics.GetHttpHandler())
 	s.mux.HandleFunc("/sync", s.syncHandler)
 	s.mux.HandleFunc("/view", s.showJobStateHandler)


### PR DESCRIPTION
主要解决 CCR Syncer 无法自动检测 Doris 集群 BE 节点变化的问题，同时优化了相关代码结构。

### 问题
Meta 对象会缓存 Backend（BE）信息，只在首次调用时从 FE 获取，之后一直使用缓存
当 Doris 集群扩容时，CCR Syncer 无法感知到 BE 节点的变化
当syncer任务从增量转到全量同步时，ccr将不完整的backend信息发送给下游集群做restore
产生报错：failed to get remote be address of be: xxx

### 方案
删除 getBackend 缓存机制


