### PR TITLE
fix: job_status API not updating after state change

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -4363,6 +4363,9 @@ func (j *Job) changeJobState(state JobState) error {
 		j.State = originState
 		return err
 	}
+
+	j.updateJobStatus()
+
 	log.Debugf("change job %s state from %s to %s", j.Name, originState, state)
 	return nil
 }


### PR DESCRIPTION
## Problem
When calling Pause/Resume API, the job state is correctly updated in the database, but the `/job_status` API does not reflect the new state immediately and continues to show the old state.

## Root Cause
`rawStatus.state` is only updated periodically through `updateJobStatus()` in the `sync()` method within the `run()` loop. When the job is paused or stopped, periodic sync no longer occurs, leaving `rawStatus.state` out of sync.

## Solution
In `changeJobState()`, immediately call `updateJobStatus()` after persisting the state to ensure `rawStatus.state` is synchronized, maintaining consistency between persisted state (`j.State`) and in-memory state (`rawStatus.state`).