### PR TITLE
improvement: optimize job deletion mechanism

### DIFF
--- a/pkg/ccr/base/spec.go
+++ b/pkg/ccr/base/spec.go
@@ -17,6 +17,7 @@
 package base
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"regexp"
@@ -723,6 +724,7 @@ func (s *Spec) CancelRestoreIfExists(snapshotName string) error {
 	}
 
 	if info == nil || info.State == RestoreStateCancelled || info.State == RestoreStateFinished {
+		log.Debugf("skip cancel restore %s: not found or already completed/cancelled", snapshotName)
 		return nil
 	}
 
@@ -731,6 +733,53 @@ func (s *Spec) CancelRestoreIfExists(snapshotName string) error {
 	_, err = db.Exec(sql)
 	if err != nil {
 		return xerror.Wrapf(err, xerror.Normal, "cancel restore failed, sql: %s", sql)
+	}
+	return nil
+}
+
+// CancelBackupIfExists cancels a specific backup job if it exists and is running.
+func (s *Spec) CancelBackupIfExists(snapshotName string) error {
+	log.Tracef("cancel backup %s, db name: %s", snapshotName, s.Database)
+
+	db, err := s.Connect()
+	if err != nil {
+		return err
+	}
+
+	// Query backup status for this snapshot
+	sql := fmt.Sprintf("SHOW BACKUP FROM %s WHERE SnapshotName = '%s'",
+		utils.FormatKeywordName(s.Database), snapshotName)
+	log.Debugf("check backup state sql: %s", sql)
+	rows, err := db.Query(sql)
+	if err != nil {
+		return xerror.Wrapf(err, xerror.Normal, "show backup failed, sql: %s", sql)
+	}
+	defer rows.Close()
+
+	var backupState BackupState = BackupStateUnknown
+	if rows.Next() {
+		rowParser := utils.NewRowParser()
+		if err := rowParser.Parse(rows); err != nil {
+			return xerror.Wrap(err, xerror.Normal, "parse backup info failed")
+		}
+
+		info, err := parseBackupInfo(rowParser)
+		if err != nil {
+			return xerror.Wrap(err, xerror.Normal, "parse backup info failed")
+		}
+		backupState = info.State
+	}
+
+	if backupState == BackupStateCancelled || backupState == BackupStateFinished || backupState == BackupStateUnknown {
+		log.Debugf("skip cancel backup %s: not found or already completed/cancelled", snapshotName)
+		return nil
+	}
+
+	cancelSql := fmt.Sprintf("CANCEL BACKUP FROM %s", utils.FormatKeywordName(s.Database))
+	log.Infof("cancelling backup %s, sql: %s", snapshotName, cancelSql)
+	_, err = db.Exec(cancelSql)
+	if err != nil {
+		return xerror.Wrapf(err, xerror.Normal, "cancel backup failed, sql: %s", cancelSql)
 	}
 	return nil
 }
@@ -1131,13 +1180,25 @@ func (s *Spec) waitTransactionDone(txnId int64) error {
 	return xerror.Errorf(xerror.Normal, "no transaction status found")
 }
 
-func (s *Spec) WaitTransactionDone(txnId int64) {
+// WaitTransactionDoneWithContext waits for transaction to become VISIBLE, with context support for cancellation.
+// Returns nil if transaction is visible, or context.Canceled/context.DeadlineExceeded if cancelled.
+func (s *Spec) WaitTransactionDoneWithContext(ctx context.Context, txnId int64) error {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
 	for {
-		if err := s.waitTransactionDone(txnId); err != nil {
-			log.Errorf("wait transaction done failed, err +%v", err)
-			time.Sleep(time.Second)
-		} else {
-			break
+		select {
+		case <-ctx.Done():
+			// Job is deleted or cancelled
+			log.Infof("wait transaction %d cancelled: %v", txnId, ctx.Err())
+			return ctx.Err()
+		case <-ticker.C:
+			if err := s.waitTransactionDone(txnId); err != nil {
+				log.Debugf("transaction %d not visible yet, continue waiting: %v", txnId, err)
+			} else {
+				log.Infof("transaction %d is visible", txnId)
+				return nil
+			}
 		}
 	}
 }

--- a/pkg/ccr/base/specer.go
+++ b/pkg/ccr/base/specer.go
@@ -17,6 +17,8 @@
 package base
 
 import (
+	"context"
+
 	"github.com/selectdb/ccr_syncer/pkg/ccr/record"
 	"github.com/selectdb/ccr_syncer/pkg/utils"
 )
@@ -45,12 +47,13 @@ type Specer interface {
 	GetValidBackupJob(snapshotNamePrefix string) (string, error)
 	GetValidRestoreJob(snapshotNamePrefix string) (string, error)
 	CancelRestoreIfExists(snapshotName string) error
+	CancelBackupIfExists(snapshotName string) error
 	CreatePartialSnapshot(snapshotName, table string, partitions []string) error
 	CreateSnapshot(snapshotName string, tables []string) error
 	CheckBackupFinished(snapshotName string) (bool, error)
 	CheckRestoreFinished(snapshotName string) (bool, error)
 	GetRestoreSignatureNotMatchedTableOrView(snapshotName string) (string, bool, error)
-	WaitTransactionDone(txnId int64) // busy wait
+	WaitTransactionDoneWithContext(ctx context.Context, txnId int64) error // wait with context support for cancellation
 
 	LightningSchemaChange(srcDatabase string, tableAlias string, changes *record.ModifyTableAddOrDropColumns) error
 	RenameColumn(destTableName string, renameColumn *record.RenameColumn) error

--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -240,6 +240,14 @@ type Job struct {
 
 	lock sync.Mutex `json:"-"`
 
+	// Current running backup/restore names for cancellation on deletion
+	currentBackupName  string `json:"-"`
+	currentRestoreName string `json:"-"`
+
+	// Context for cancellation on deletion
+	ctx    context.Context    `json:"-"`
+	cancel context.CancelFunc `json:"-"`
+
 	// Replication number policy: -1 means inherit from upstream (default), >0 means fixed replica num, 0 is invalid
 	ReplicationNum int `json:"replication_num,omitempty"`
 }
@@ -577,6 +585,7 @@ func (j *Job) partialSync() error {
 			}
 			if snapshotName != "" {
 				log.Infof("partial sync status: there has a exist backup job %s", snapshotName)
+				j.currentBackupName = snapshotName
 				j.progress.NextSubVolatile(WaitBackupDone, snapshotName)
 				return nil
 			}
@@ -596,12 +605,14 @@ func (j *Job) partialSync() error {
 			return err
 		}
 
+		j.currentBackupName = snapshotName
 		j.progress.NextSubVolatile(WaitBackupDone, snapshotName)
 		return nil
 
 	case WaitBackupDone:
 		// Step 2: Wait backup job done
 		snapshotName := j.progress.InMemoryData.(string)
+
 		backupFinished, err := j.ISrc.CheckBackupFinished(snapshotName)
 		if err != nil {
 			j.progress.NextSubVolatile(BeginCreateSnapshot, snapshotName)
@@ -613,6 +624,7 @@ func (j *Job) partialSync() error {
 			return nil
 		}
 
+		j.currentBackupName = "" // Backup done, clear the name
 		j.progress.NextSubCheckpoint(GetSnapshotInfo, snapshotName)
 
 	case GetSnapshotInfo:
@@ -751,6 +763,7 @@ func (j *Job) partialSync() error {
 			if name != "" {
 				log.Infof("partial sync status: there has a exist restore job %s", name)
 				inMemoryData.RestoreLabel = name
+				j.currentRestoreName = name
 				j.progress.NextSubVolatile(WaitRestoreDone, inMemoryData)
 				break
 			}
@@ -824,6 +837,7 @@ func (j *Job) partialSync() error {
 		}
 		log.Tracef("partial sync restore snapshot resp: %v", restoreResp)
 		inMemoryData.RestoreLabel = restoreSnapshotName
+		j.currentRestoreName = restoreSnapshotName
 
 		j.progress.NextSubVolatile(WaitRestoreDone, inMemoryData)
 		return nil
@@ -869,6 +883,7 @@ func (j *Job) partialSync() error {
 		}
 		j.progress.TableNameMapping = utils.MergeMap(
 			j.progress.TableNameMapping, inMemoryData.TableNameMapping)
+		j.currentRestoreName = "" // Restore done, clear the name
 		j.progress.NextSubCheckpoint(PersistRestoreInfo, restoreSnapshotName)
 
 	case PersistRestoreInfo:
@@ -905,6 +920,7 @@ func (j *Job) partialSync() error {
 
 			// Save the replace result
 			j.progress.TableAliases = nil
+			j.currentRestoreName = "" // Restore done, clear the name
 			j.progress.NextSubCheckpoint(PersistRestoreInfo, j.progress.PersistData)
 		}
 
@@ -975,6 +991,7 @@ func (j *Job) fullSync() error {
 			}
 			if snapshotName != "" {
 				log.Infof("fullsync status: there has a exist backup job %s", snapshotName)
+				j.currentBackupName = snapshotName
 				j.progress.NextSubVolatile(WaitBackupDone, snapshotName)
 				return nil
 			}
@@ -1016,12 +1033,14 @@ func (j *Job) fullSync() error {
 		if err := j.ISrc.CreateSnapshot(snapshotName, backupTableList); err != nil {
 			return err
 		}
+		j.currentBackupName = snapshotName
 		j.progress.NextSubVolatile(WaitBackupDone, snapshotName)
 		return nil
 
 	case WaitBackupDone:
 		// Step 2: Wait backup job done
 		snapshotName := j.progress.InMemoryData.(string)
+
 		backupFinished, err := j.ISrc.CheckBackupFinished(snapshotName)
 		if err != nil {
 			j.progress.NextSubVolatile(BeginCreateSnapshot, snapshotName)
@@ -1032,6 +1051,7 @@ func (j *Job) fullSync() error {
 			return nil
 		}
 
+		j.currentBackupName = "" // Backup done, clear the name
 		j.progress.NextSubCheckpoint(GetSnapshotInfo, snapshotName)
 
 	case GetSnapshotInfo:
@@ -1166,6 +1186,7 @@ func (j *Job) fullSync() error {
 			if restoreSnapshotName != "" {
 				log.Infof("fullsync status: there has a exist restore job %s", restoreSnapshotName)
 				inMemoryData.RestoreLabel = restoreSnapshotName
+				j.currentRestoreName = restoreSnapshotName
 				j.progress.NextSubVolatile(WaitRestoreDone, inMemoryData)
 				break
 			}
@@ -1273,6 +1294,7 @@ func (j *Job) fullSync() error {
 		log.Tracef("fullsync restore snapshot resp: %v", restoreResp)
 
 		inMemoryData.RestoreLabel = restoreSnapshotName
+		j.currentRestoreName = restoreSnapshotName
 		j.progress.NextSubVolatile(WaitRestoreDone, inMemoryData)
 		return nil
 
@@ -1294,6 +1316,12 @@ func (j *Job) fullSync() error {
 		}
 
 		for {
+			// Check if job is deleted, exit and let Delete() handle the cancel
+			if j.isDeleted.Load() {
+				log.Infof("job %s deleted during restore check loop, exiting", j.Name)
+				return nil
+			}
+
 			restoreFinished, err := j.IDest.CheckRestoreFinished(restoreSnapshotName)
 			if err != nil && errors.Is(err, base.ErrRestoreSignatureNotMatched) {
 				// We need rebuild the exists table.
@@ -1374,6 +1402,7 @@ func (j *Job) fullSync() error {
 				commitSeq = tableCommitSeqMap[j.Src.TableId]
 			}
 
+			j.currentRestoreName = "" // Restore done, clear the name
 			j.progress.CommitNextSubWithPersist(commitSeq, PersistRestoreInfo, restoreSnapshotName)
 			break
 		}
@@ -1414,6 +1443,7 @@ func (j *Job) fullSync() error {
 
 			// Save the replace result
 			j.progress.TableAliases = nil
+			j.currentRestoreName = "" // Restore done, clear the name
 			j.progress.NextSubCheckpoint(PersistRestoreInfo, j.progress.PersistData)
 		}
 
@@ -2011,7 +2041,10 @@ func (j *Job) handleUpsert(binlog *festruct.TBinlog) error {
 		log.Tracef("commit txn %d resp: %v", txnId, resp)
 
 		if statusCode := resp.Status.GetStatusCode(); statusCode == tstatus.TStatusCode_PUBLISH_TIMEOUT {
-			dest.WaitTransactionDone(txnId)
+			if err := dest.WaitTransactionDoneWithContext(j.ctx, txnId); err != nil {
+				rollback(err, inMemoryData)
+				return err
+			}
 		} else if statusCode != tstatus.TStatusCode_OK {
 			err := xerror.Errorf(xerror.Normal, "commit txn failed, status: %v", resp.Status)
 			rollback(err, inMemoryData)
@@ -3623,7 +3656,9 @@ func (j *Job) handleNonBarrierBinlog(binlog *festruct.TBinlog) error {
 	if prevTxnId := j.progress.PrevTxnId; prevTxnId != -1 {
 		dest := &j.Dest
 		log.Infof("wait prev txn id: %d published", prevTxnId)
-		dest.WaitTransactionDone(prevTxnId)
+		if err := dest.WaitTransactionDoneWithContext(j.ctx, prevTxnId); err != nil {
+			return err
+		}
 		j.progress.PrevTxnId = -1
 	}
 
@@ -3802,7 +3837,9 @@ func (j *Job) incrementalSyncInternal() error {
 			// consume prev txn id for not to check and wait prev transaction finished
 			if j.progress.PrevTxnId != -1 {
 				log.Infof("consume prev txn id: %d", j.progress.PrevTxnId)
-				j.Dest.WaitTransactionDone(j.progress.PrevTxnId)
+				if err := j.Dest.WaitTransactionDoneWithContext(j.ctx, j.progress.PrevTxnId); err != nil {
+					return err
+				}
 				j.progress.PrevTxnId = -1
 				j.progress.Persist()
 			}
@@ -3841,6 +3878,7 @@ func (j *Job) recoverJobProgress() error {
 		return err
 	} else {
 		j.progress = progress
+		j.progress.isDeleted = &j.isDeleted // Set reference to job's isDeleted flag
 		return nil
 	}
 }
@@ -3937,6 +3975,12 @@ func (j *Job) sync() error {
 
 // if err is Panic, return it
 func (j *Job) handleError(jobName string, err error) error {
+	// context.Canceled is normal when job is deleted, don't log as error
+	if errors.Is(err, context.Canceled) {
+		log.Debugf("job %s sync cancelled due to deletion", jobName)
+		return nil
+	}
+
 	var xerr *xerror.XError
 	if !errors.As(err, &xerr) {
 		log.Errorf("convert error to xerror failed, err: %+v", err)
@@ -3993,7 +4037,12 @@ func (j *Job) run() {
 				break
 			}
 
-			log.Warnf("job sync failed, job: %s, err: %+v", j.Name, err)
+			// Use debug level for context.Canceled (normal deletion flow)
+			if errors.Is(err, context.Canceled) {
+				log.Debugf("job sync cancelled, job: %s", j.Name)
+			} else {
+				log.Warnf("job sync failed, job: %s, err: %+v", j.Name, err)
+			}
 			panicError = j.handleError(j.Name, err)
 		}
 	}
@@ -4083,6 +4132,9 @@ func (j *Job) Run() error {
 	gls.ResetGls(gls.GoID(), map[any]any{"job": j.Name})
 	defer gls.DeleteGls(gls.GoID())
 
+	// Initialize context for cancellation
+	j.ctx, j.cancel = context.WithCancel(context.Background())
+
 	// retry 3 times to check IsProgressExist
 	var isProgressExist bool
 	var err error
@@ -4104,6 +4156,7 @@ func (j *Job) Run() error {
 		}
 	} else {
 		j.progress = NewJobProgress(j.Name, j.SyncType, j.db)
+		j.progress.isDeleted = &j.isDeleted // Set reference to job's isDeleted flag
 		info := fmt.Sprintf("new job, job: %s, sync type: %v", j.Name, j.SyncType)
 		if err := j.NewSnapshot(0, info); err != nil {
 			return err
@@ -4215,6 +4268,40 @@ func (j *Job) Stop() {
 // delete job
 func (j *Job) Delete() {
 	j.isDeleted.Store(true)
+
+	// 1. Set interrupt signal to let pipeline loop detect deletion
+	atomic.AddInt32(&j.Extra.InterruptSignal, 1)
+	select {
+	case j.Extra.InterruptCh <- struct{}{}:
+	default:
+		// Channel may be full, ignore
+	}
+
+	// 2. Cancel job context to interrupt WaitTransactionDone etc.
+	if j.cancel != nil {
+		j.cancel()
+	}
+
+	// 3. Cancel pipeline context to interrupt async ingest goroutines
+	if j.pipelineCtx != nil {
+		j.pipelineCtx.Cancel()
+	}
+
+	// 4. Cancel any running backup/restore jobs
+	if j.currentBackupName != "" {
+		log.Infof("job %s deleted, cancelling backup: %s", j.Name, j.currentBackupName)
+		if err := j.ISrc.CancelBackupIfExists(j.currentBackupName); err != nil {
+			log.Warnf("job %s failed to cancel backup %s: %v", j.Name, j.currentBackupName, err)
+		}
+	}
+	if j.currentRestoreName != "" {
+		log.Infof("job %s deleted, cancelling restore: %s", j.Name, j.currentRestoreName)
+		if err := j.IDest.CancelRestoreIfExists(j.currentRestoreName); err != nil {
+			log.Warnf("job %s failed to cancel restore %s: %v", j.Name, j.currentRestoreName, err)
+		}
+	}
+
+	// 5. Close stop channel
 	close(j.stop)
 }
 
@@ -4223,12 +4310,13 @@ func (j *Job) maybeDeleted() bool {
 		return false
 	}
 
-	// job had been deleted
-	log.Infof("job deleted, job: %s, remove in db", j.Name)
-	if err := j.db.RemoveJob(j.Name); err != nil {
-		log.Errorf("remove job failed, job: %s, err: %+v", j.Name, err)
-	}
+	// Job has been deleted, just exit gracefully.
+	log.Infof("job deleted, job: %s, exiting gracefully", j.Name)
 	return true
+}
+
+func (j *Job) IsDeleted() bool {
+	return j.isDeleted.Load()
 }
 
 func (j *Job) updateFrontends() error {

--- a/pkg/ccr/job_manager.go
+++ b/pkg/ccr/job_manager.go
@@ -27,6 +27,7 @@ import (
 )
 
 var errJobExist = xerror.NewWithoutStack(xerror.Normal, "job exist")
+var errJobDeleting = xerror.NewWithoutStack(xerror.Normal, "job is being deleted, please wait and retry")
 var errJobName = xerror.NewWithoutStack(xerror.Normal, "job name does not match the regex of doris")
 
 // job manager is thread safety
@@ -67,7 +68,11 @@ func (jm *JobManager) AddJob(job *Job) error {
 	}
 
 	// Step 1: check job exist
-	if _, ok := jm.jobs[job.Name]; ok {
+	if existingJob, ok := jm.jobs[job.Name]; ok {
+		// Distinguish between "job is running" and "job is being deleted"
+		if existingJob.IsDeleted() {
+			return xerror.XWrapf(errJobDeleting, "job: %s", job.Name)
+		}
 		return xerror.XWrapf(errJobExist, "job: %s", job.Name)
 	}
 
@@ -135,16 +140,19 @@ func (jm *JobManager) RemoveJob(name string) error {
 		return xerror.Errorf(xerror.Normal, "job not exist: %s", name)
 	}
 
-	// stop job
+	// Step 1: Mark job as deleted and interrupt running operations
 	job.Delete()
-	if err := jm.db.RemoveJob(name); err == nil {
-		delete(jm.jobs, name)
-		log.Infof("job [%s] has been successfully deleted, but it needs to wait until an isochronous point before it will completely STOP", name)
-		return nil
-	} else {
+
+	// Step 2: Remove from database (only once, maybeDeleted no longer does this)
+	if err := jm.db.RemoveJob(name); err != nil {
 		log.Errorf("remove job [%s] in db failed: %+v, but job is stopped", name, err)
 		return fmt.Errorf("remove job [%s] in db failed, but job is stopped, if can resume/delete, please do it manually", name)
 	}
+
+	// Step 3: Don't remove from map here!
+
+	log.Infof("job [%s] has been marked for deletion, will be removed from map after goroutine exits", name)
+	return nil
 }
 
 // go run all jobs and wait for stop chan
@@ -181,11 +189,28 @@ func (jm *JobManager) runJob(job *Job) {
 	jm.wg.Add(1)
 
 	go func() {
+		defer func() {
+			// 1. Recover from panic to ensure cleanup always runs
+			if r := recover(); r != nil {
+				log.Errorf("job %s panic: %v", job.Name, r)
+			}
+
+			// 2. If job was deleted, remove from map after goroutine exits
+			if job.IsDeleted() {
+				jm.lock.Lock()
+				delete(jm.jobs, job.Name)
+				jm.lock.Unlock()
+				log.Infof("job [%s] goroutine exited, removed from map", job.Name)
+			}
+
+			// 3. Always call wg.Done()
+			jm.wg.Done()
+		}()
+
 		err := job.Run()
 		if err != nil {
 			log.Errorf("job run failed, job name: %s, error: %+v", job.Name, err)
 		}
-		jm.wg.Done()
 	}()
 }
 

--- a/pkg/ccr/job_pipeline.go
+++ b/pkg/ccr/job_pipeline.go
@@ -481,7 +481,9 @@ func (j *Job) getNextBinlogs() error {
 		// consume prev txn id for not to check and wait prev transaction finished
 		if j.progress.PrevTxnId != -1 {
 			log.Infof("consume prev txn id: %d", j.progress.PrevTxnId)
-			j.Dest.WaitTransactionDone(j.progress.PrevTxnId)
+			if err := j.Dest.WaitTransactionDoneWithContext(j.pipelineCtx.Context, j.progress.PrevTxnId); err != nil {
+				return err
+			}
 			j.progress.PrevTxnId = -1
 			j.progress.Persist()
 		}
@@ -798,8 +800,40 @@ func (j *Job) commitTxn(ctx *TxnContext) error {
 	}
 	log.Tracef("commit txn %d resp: %v", txnId, resp)
 
-	if statusCode := resp.Status.GetStatusCode(); statusCode == tstatus.TStatusCode_PUBLISH_TIMEOUT {
-		dest.WaitTransactionDone(txnId)
+	statusCode := resp.Status.GetStatusCode()
+
+	// Failpoint: simulate PUBLISH_TIMEOUT with slow wait to test job deletion during publish
+	if utils.HasJobFailpoint(j.Name, "publish_wait_test") {
+		log.Infof("failpoint: publish_wait_test triggered for job %s, forcing PUBLISH_TIMEOUT", j.Name)
+		statusCode = tstatus.TStatusCode_PUBLISH_TIMEOUT
+	}
+
+	if statusCode == tstatus.TStatusCode_PUBLISH_TIMEOUT {
+		// Use pipeline context for cancellation support when waiting for transaction
+		var waitCtx context.Context
+		if j.pipelineCtx != nil && j.pipelineCtx.Context != nil {
+			waitCtx = j.pipelineCtx.Context
+		} else {
+			log.Warnf("pipelineCtx is nil in commitTxn, wait transaction %d without cancellation support", txnId)
+			waitCtx = context.Background()
+		}
+
+		// Failpoint: add delay before checking transaction status
+		if utils.HasJobFailpoint(j.Name, "publish_wait_test") {
+			log.Infof("failpoint: publish_wait_test waiting 30 seconds for job %s (can be cancelled)", j.Name)
+			select {
+			case <-waitCtx.Done():
+				log.Warnf("failpoint: publish_wait_test cancelled for job %s: %v", j.Name, waitCtx.Err())
+				return waitCtx.Err()
+			case <-time.After(30 * time.Second):
+				log.Infof("failpoint: publish_wait_test wait completed for job %s", j.Name)
+			}
+		}
+
+		if err := dest.WaitTransactionDoneWithContext(waitCtx, txnId); err != nil {
+			log.Warnf("wait transaction %d cancelled: %v", txnId, err)
+			return err
+		}
 	} else if statusCode != tstatus.TStatusCode_OK {
 		err := xerror.Errorf(xerror.Normal, "commit txn failed, status: %v", resp.Status)
 		return err

--- a/pkg/ccr/job_progress.go
+++ b/pkg/ccr/job_progress.go
@@ -19,6 +19,7 @@ package ccr
 import (
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/selectdb/ccr_syncer/pkg/storage"
@@ -174,8 +175,9 @@ type JobPartialSyncData struct {
 }
 
 type JobProgress struct {
-	JobName string     `json:"job_name"`
-	db      storage.DB `json:"-"`
+	JobName   string       `json:"job_name"`
+	db        storage.DB   `json:"-"`
+	isDeleted *atomic.Bool `json:"-"` // Reference to Job's isDeleted flag, used to prevent persist after deletion
 
 	// Table/DB big sync state machine states
 	SyncState SyncState `json:"sync_state"`
@@ -432,12 +434,26 @@ func (j *JobProgress) Rollback() {
 // write progress to db, busy loop until success
 // TODO: add timeout check
 func (j *JobProgress) Persist() {
+	// Check if job is deleted before persisting.
+	// This prevents a deleted job's goroutine from overwriting a new job's progress
+	// when they have the same name (the database uses job_name as the primary key).
+	if j.isDeleted != nil && j.isDeleted.Load() {
+		log.Infof("job %s is deleted, skip persist progress", j.JobName)
+		return
+	}
+
 	log.Tracef("update job progress, state: %s, subState: %s, commitSeq: %d, prevCommitSeq: %d",
 		j.SyncState, j.SubSyncState, j.CommitSeq, j.PrevCommitSeq)
 
 	defer xmetrics.RecordJobProgressPersist(j.JobName)()
 
 	for {
+		// Check again in the loop in case job is deleted during retry
+		if j.isDeleted != nil && j.isDeleted.Load() {
+			log.Infof("job %s is deleted during persist retry, abort", j.JobName)
+			return
+		}
+
 		// Step 1: to json
 		// TODO: fix to json error
 		jsonBytes, err := json.Marshal(j)

--- a/pkg/ccr/specer_mock.go
+++ b/pkg/ccr/specer_mock.go
@@ -310,15 +310,3 @@ func (mr *MockSpecerMockRecorder) Valid() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Valid", reflect.TypeOf((*MockSpecer)(nil).Valid))
 }
-
-// WaitTransactionDone mocks base method.
-func (m *MockSpecer) WaitTransactionDone(txnId int64) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "WaitTransactionDone", txnId)
-}
-
-// WaitTransactionDone indicates an expected call of WaitTransactionDone.
-func (mr *MockSpecerMockRecorder) WaitTransactionDone(txnId any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitTransactionDone", reflect.TypeOf((*MockSpecer)(nil).WaitTransactionDone), txnId)
-}


### PR DESCRIPTION
## 问题
issue: https://github.com/selectdb/ccr-syncer/issues/648
- 同名任务冲突：旧任务 goroutine 未完全退出时创建同名新任务，导致 progress 表被覆盖、数据库记录被误删
- 删除延迟：全量同步阶段（backup/restore）或事务等待阶段删除任务需要等待操作完成

## 改动
1. 防止同名任务冲突
        - JobManager 延迟从 map 删除，等待 goroutine 完全退出后再移除
        - 创建任务时检查是否有同名任务正在删除中，返回 job is being deleted, please wait and retry
        - Persist() 检查 isDeleted，防止旧任务覆盖新任务 progress
2. 加速 Backup/Restore 取消
        - Job 添加 currentBackupName / currentRestoreName 字段跟踪当前操作
        - Delete() 取消 backup/restore 任务
3. 加速事务等待取消
        - Job 添加 ctx / cancel 字段
        - Delete() 调用 cancel() 取消所有等待中的操作
        - 4 处 WaitTransactionDone 调用改为 WaitTransactionDoneWithContext
        - 删除无参数版本的 WaitTransactionDone