### PR TITLE
Fix: Persist Dest.TableId after partialSync in TableSync mode

### DIFF
--- a/pkg/ccr/job.go
+++ b/pkg/ccr/job.go
@@ -949,6 +949,9 @@ func (j *Job) partialSync() error {
 				j.progress.ShadowIndexes = nil
 			}
 			j.Dest.TableId = destTable.Id
+			if err := j.persistJob(); err != nil {
+				return err
+			}
 			j.progress.TableMapping = nil
 			j.progress.TableCommitSeqMap = nil
 			j.progress.NextWithPersist(commitSeq, TableIncrementalSync, Done, "")


### PR DESCRIPTION
### 问题
TableSync 模式下，partialSync 完成后更新了内存中的 Dest.TableId，但未调用 persistJob() 将其写入数据库。此时增量同步使用内存中的正确值，一切正常。但 syncer 重启后（升级、异常退出等），从数据库加载到的仍是旧的 Dest.TableId，导致后续Upsert-Binlog在 begin txn 阶段报错：can't find table id: xxxx in db: xxx。

该问题仅影响 TableSync 模式，且仅在触发过 partialSync 后重启 syncer 才会复现。

### 修复
在 partialSync 完成的 PersistRestoreInfo 阶段（TableSync 分支），Dest.TableId 赋值后补充 persistJob() 调用，与 fullSync 的行为保持一致。

