### PR TITLE
fix: avoid nil panic when transaction becomes visible

### DIFF
--- a/pkg/ccr/base/spec.go
+++ b/pkg/ccr/base/spec.go
@@ -1194,14 +1194,15 @@ func (s *Spec) WaitTransactionDoneWithContext(ctx context.Context, txnId int64) 
 			log.Infof("wait transaction %d cancelled: %v", txnId, ctx.Err())
 			return ctx.Err()
 		case <-ticker.C:
-			if err := s.waitTransactionDone(txnId); strings.Contains(err.Error(), msg) {
-				return xerror.Errorf(xerror.Meta, "txn %d does not exist, maybe already finished and cleaned up, spec: %s", txnId, s.String())
-			} else if err != nil {
-				log.Debugf("transaction %d not visible yet, continue waiting: %v", txnId, err)
-			} else {
+			err := s.waitTransactionDone(txnId)
+			if err == nil {
 				log.Infof("transaction %d is visible", txnId)
 				return nil
 			}
+			if strings.Contains(err.Error(), msg) {
+				return xerror.Errorf(xerror.Meta, "txn %d does not exist, maybe already finished and cleaned up, spec: %s", txnId, s.String())
+			}
+			log.Debugf("transaction %d not visible yet, continue waiting: %v", txnId, err)
 		}
 	}
 }


### PR DESCRIPTION
#673 这个pr没有先判断err!=nil，如果err=nil，进入到err.Error()会报错